### PR TITLE
Remove log from ``push_state_dict``

### DIFF
--- a/torchstore/_state_dict_utils.py
+++ b/torchstore/_state_dict_utils.py
@@ -24,7 +24,6 @@ async def push_state_dict(store, state_dict, key):
     """
     flattened_state_dict, mapping = flatten_state_dict(state_dict)
     for flattened_key, value in flattened_state_dict.items():
-        logger.info(f"Putting {flattened_key}")
         await store.put(f"{key}{DELIM}{flattened_key}", value)
 
     await store.put(f"{key}{DELIM}{MAPPING}", mapping)


### PR DESCRIPTION
pls

The logging is already handled in the actual put call - this is overly verbose and at the INFO level so hard to turn off.