### PR TITLE
Chunk size 2MB and 4MB supported

### DIFF
--- a/torchstore/transport/buffers.py
+++ b/torchstore/transport/buffers.py
@@ -24,8 +24,19 @@ except ImportError:
 # TODO: for some reason, RDMABuffer is breaking for certain tensors on the HF models (qwen, llama)
 # but setting this chunk size works around the issue until we can fix it
 # N.B. from benchmarking, we know the ideal size is any size >=256mb.
-RDMDA_CHUNK_SIZE_MB: int = int(os.environ.get("TORCHSTORE_RDMDA_CHUNK_SIZE_MB", "1"))
-assert RDMDA_CHUNK_SIZE_MB <= 1024, "Monarch does not support 1gb chunks via rdma"
+
+# Check for misspelled environment variable for backward compatibility
+rdma_chunk_size_env = os.environ.get("TORCHSTORE_RDMDA_CHUNK_SIZE_MB")
+if rdma_chunk_size_env is not None:
+    logging.warning(
+        "Using deprecated environment variable 'TORCHSTORE_RDMDA_CHUNK_SIZE_MB'. "
+        "Please use 'TORCHSTORE_RDMA_CHUNK_SIZE_MB' instead."
+    )
+    RDMA_CHUNK_SIZE_MB: int = int(rdma_chunk_size_env)
+else:
+    RDMA_CHUNK_SIZE_MB: int = int(os.environ.get("TORCHSTORE_RDMA_CHUNK_SIZE_MB", "4"))
+
+assert RDMA_CHUNK_SIZE_MB <= 1024, "Monarch does not support 1gb chunks via rdma"
 
 RDMA_ENABLED: bool = os.environ.get("TORCHSTORE_RDMA_ENABLED", "1") == "1"
 
@@ -83,7 +94,7 @@ class RDMATransportBuffer(TransportBuffer):
         if tensor.dim() == 0:
             tensor = tensor.unsqueeze(0)
         byte_view = tensor.view(torch.uint8).flatten()
-        chunk_size = RDMDA_CHUNK_SIZE_MB * 1024 * 1024
+        chunk_size = RDMA_CHUNK_SIZE_MB * 1024 * 1024
         tensor_chunks = torch.split(byte_view, chunk_size, dim=0)
 
         return tensor_chunks


### PR DESCRIPTION
Re #18

There is a silent index out of range see [issue comment](https://github.com/meta-pytorch/torchstore/issues/18#issuecomment-3263239006).

After fixing this we can do chunk size 2MB and 4MB but still are running into bugs in larger chunk sizes. It might be a bug in Monarch but I'm not sure.