### PR TITLE
Add find to pyproject.toml to disambiguate top-level packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -39,3 +39,7 @@ dev = [
     "anyio",
     "pytest-asyncio",
 ]
+
+[tool.setuptools.packages.find]
+include = ["torchstore*"]
+exclude = ["assets*", "tests*", "docs*"]


### PR DESCRIPTION
After change:

```
(forge-a7401c7) [jrcummings@devvm2888.eag0 ~/projects/torchstore]$ pp pip install -e  .
Obtaining file:///home/jrcummings/projects/torchstore
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: torchstore
  Building editable for torchstore (pyproject.toml) ... done
  Created wheel for torchstore: filename=torchstore-0.1.0-0.editable-py3-none-any.whl size=4248 sha256=4927fae9ab9a024f9ed68f01fe62a4df23f884a7add8d39b88880568100434c7
  Stored in directory: /tmp/pip-ephem-wheel-cache-686agc_p/wheels/6a/73/71/0bab6e9fe2f383ce7b1dd2a2100887e489c1fbab9126b75ac1
Successfully built torchstore
Installing collected packages: torchstore
  Attempting uninstall: torchstore
    Found existing installation: torchstore 0.1.0
    Uninstalling torchstore-0.1.0:
      Successfully uninstalled torchstore-0.1.0
Successfully installed torchstore-0.1.0
```

Closes #28 