### PR TITLE
Fix CI by reordering installation of monarch in unit test workflow

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -26,10 +26,10 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install torch
         run: python -m pip install torch
-      - name: Install monarch from local wheel
-        run: python -m pip install assets/ci/monarch-0.0.1-cp310-cp310-linux_x86_64.whl --force-reinstall
       - name: Install dependencies
         run: python -m pip install -e ".[dev]"
+      - name: Install monarch from local wheel
+        run: python -m pip install assets/ci/monarch-0.0.1-cp310-cp310-linux_x86_64.whl --force-reinstall
       - name: Run slice tests (test_slice.py) with coverage
         run: |
           TORCHSTORE_RDMA_ENABLED=0 \


### PR DESCRIPTION
CI has not been working since monarch was added to dependencies.
As a temporary fix, reinstall monarch from the wheel.
Long term we need to figure out why the pip installed version is not working.