### PR TITLE
fix controller endpoint

### DIFF
--- a/torchstore/controller.py
+++ b/torchstore/controller.py
@@ -120,13 +120,13 @@ class Controller(Actor):
         self.is_initialized = True
 
     @endpoint
-    def get_controller_strategy(self) -> TorchStoreStrategy:
+    async def get_controller_strategy(self) -> TorchStoreStrategy:
         self.assert_initialized()
         assert self.strategy is not None, "Strategy is not set"
         return self.strategy
 
     @endpoint
-    def locate_volumes(
+    async def locate_volumes(
         self,
         key: str,
     ) -> Dict[str, StorageInfo]:
@@ -178,7 +178,9 @@ class Controller(Actor):
         return volume_map
 
     @endpoint
-    def notify_put(self, key: str, request: Request, storage_volume_id: str) -> None:
+    async def notify_put(
+        self, key: str, request: Request, storage_volume_id: str
+    ) -> None:
         """Notify the controller that data has been stored in a storage volume.
 
         This should called after a successful put operation to
@@ -220,13 +222,13 @@ class Controller(Actor):
         self.num_storage_volumes = None
 
     @endpoint
-    def keys(self, prefix=None) -> List[str]:
+    async def keys(self, prefix=None) -> List[str]:
         if prefix is None:
             return list(self.keys_to_storage_volumes.keys())
         return self.keys_to_storage_volumes.keys().filter_by_prefix(prefix)
 
     @endpoint
-    def notify_delete(self, key: str, storage_volume_id: str) -> None:
+    async def notify_delete(self, key: str, storage_volume_id: str) -> None:
         """
         Notify the controller that deletion of data is initiated in a storage volume.
 


### PR DESCRIPTION
Summary:
Monarch is enforcing the following check. This diff is a fix.

ValueError: <class 'torchstore.controller.Controller'> mixes both async and sync endpoints.Synchronous endpoints cannot be mixed with async endpoints because they can cause the asyncio loop to deadlock if they wait.sync: ['get_controller_strategy', 'keys', 'locate_volumes', 'notify_delete', 'notify_put'] async: ['init', 'teardown']

Differential Revision: D86155590


