### PR TITLE
add comms rdmatransport cache

### DIFF
--- a/example/torchstore_rl.py
+++ b/example/torchstore_rl.py
@@ -6,7 +6,6 @@
 
 # pyre-unsafe
 import asyncio
-
 from typing import Tuple
 
 import torch

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,6 @@ import math
 import os
 from itertools import product
 from logging import getLogger
-
 from typing import List
 
 import pytest

--- a/torchstore/__init__.py
+++ b/torchstore/__init__.py
@@ -20,7 +20,6 @@ from torchstore.api import (
     reset_client,
     shutdown,
 )
-
 from torchstore.logging import init_logging
 from torchstore.strategy import (
     ControllerStorageVolumes,

--- a/torchstore/api.py
+++ b/torchstore/api.py
@@ -7,12 +7,10 @@
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-
 from monarch.actor import get_or_spawn_controller
 
 import torchstore.state_dict_utils
 from torchstore.client import LocalClient
-
 from torchstore.controller import Controller
 from torchstore.storage_volume import StorageVolume
 from torchstore.strategy import (

--- a/torchstore/transport/buffers.py
+++ b/torchstore/transport/buffers.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+from functools import cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -17,8 +18,16 @@ except ImportError:
 
     def RDMABuffer(*args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError(
-            "RDMABuffer is not available. This environemnt was likely not built with rdma support."
+            "RDMABuffer is not available. This environment was likely not built with rdma support."
         )
+
+
+try:
+    from torchcomms._transport import RdmaTransport
+
+    torchcomms_available = True
+except ImportError:
+    torchcomms_available = False
 
 
 # TODO: we no longer need to chunk with monararch rdma buffer. Setting large chunk size for now,
@@ -33,6 +42,76 @@ def rdma_available() -> bool:
         os.environ.get("TORCHSTORE_RDMA_ENABLED", "1") == "1"
     )  # TODO: enable on this build
     return rdma_enabled and monarch_rdma_available()
+
+
+@cache
+def torchcomms_rdma_available() -> bool:
+    rdma_enabled = os.environ.get("USE_TORCHCOMMS_RDMA", "0") == "1"
+    # (1) CommsRDMA flag is enabled (2) torchcomms lib is available (3) RDMA is supported
+    return rdma_enabled and torchcomms_available and RdmaTransport.supported()
+
+
+TransportAndAddress = Tuple["RdmaTransport", bytes]
+
+
+class RdmaTransportCache:
+    def __init__(self) -> None:
+        assert torchcomms_rdma_available(), "TorchComms RDMA is not available."
+        # {key: {device: (transport, address)}}
+        self.transports: Dict[str, Dict[int, TransportAndAddress]] = {}
+
+    @classmethod
+    def try_init(cls) -> Optional["RdmaTransportCache"]:
+        try:
+            return cls()
+        except Exception as e:
+            logging.info(f"Failed to init RdmaTransportCache: {e}")
+            return None
+
+    def _device_to_index(self, device: torch.device | int) -> int:
+        if isinstance(device, int):
+            return device
+        else:
+            return 0 if device.type == "cpu" else device.index
+
+    def put(self, key: str, device: torch.device | int) -> TransportAndAddress:
+        index = self._device_to_index(device)
+        transport = RdmaTransport(torch.device(index))
+
+        if key not in self.transports:
+            self.transports[key] = {}
+        val = (transport, transport.bind())
+        self.transports[key][index] = val
+        return val
+
+    def _get(self, key: str, device: torch.device | int) -> TransportAndAddress:
+        index = self._device_to_index(device)
+        return self.transports[key][index]
+
+    def get(self, key: str, device: torch.device | int):
+        if not self.contains(key, device):
+            return self.put(key, device)
+        return self._get(key, device)
+
+    def contains(self, key: str, device: torch.device | int) -> bool:
+        index = self._device_to_index(device)
+        return key in self.transports and index in self.transports[key]
+
+
+class TransportContext:
+    RDMA_TRANSPORT_CACHE = "rdma_transport_cache"
+
+    def __init__(self):
+        self.transport_context = {}
+        self.transport_context[
+            self.RDMA_TRANSPORT_CACHE
+        ] = RdmaTransportCache.try_init()
+
+    def get_transport_context(self) -> Dict[Any, Any]:
+        return self.transport_context
+
+    def get_rdma_transport_cache(self) -> RdmaTransportCache:
+        return self.transport_context.get(self.RDMA_TRANSPORT_CACHE, None)
 
 
 class TransportBuffer:

--- a/torchstore/transport/pipe.py
+++ b/torchstore/transport/pipe.py
@@ -7,11 +7,14 @@
 import copy
 from dataclasses import dataclass
 from logging import getLogger
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, TYPE_CHECKING
 
 import torch
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._utils import _compute_local_shape_and_global_offset
+
+if TYPE_CHECKING:
+    from torchstore.strategy import StorageVolumeRef
 
 from torchstore.transport.buffers import (
     MonarchTransportBuffer,
@@ -131,8 +134,9 @@ class Pipe:
     Transport wrapper for communicating from local clients to storage volumes.
     """
 
-    def __init__(self, storage_volume) -> None:
-        self.storage_volume = storage_volume
+    def __init__(self, storage_volume_ref: "StorageVolumeRef") -> None:
+        self.storage_volume_ref = storage_volume_ref
+        self.storage_volume = storage_volume_ref.volume
 
     def create_transport_buffer(self) -> TransportBuffer:
         # TODO: eventually this should be dependent on the connections available to a storage_volume

--- a/torchstore/utils.py
+++ b/torchstore/utils.py
@@ -10,7 +10,6 @@ from logging import getLogger
 from typing import List, Tuple, TYPE_CHECKING
 
 import torch
-
 from monarch.actor import this_host
 
 from torchstore.transport import TensorSlice


### PR DESCRIPTION
adds initial support for torchcomms rdmatransport objects, as well as a kv cache to hold them

Differential Revision: D87804517


