### PR TITLE
provide default volumeid for HostStrategy init

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import socket
 from logging import getLogger
 
 import pytest
@@ -20,7 +21,8 @@ init_logging()
 logger = getLogger(__name__)
 
 
-@pytest.mark.parametrize(*transport_plus_strategy_params())
+# Ensure we have some kind of basic coverage for HostStrategy
+@pytest.mark.parametrize(*transport_plus_strategy_params(with_host_strategy=True))
 @pytest.mark.asyncio
 async def test_basic(strategy_params, transport_type):
     """Test basic put/get functionality for multiple processes"""
@@ -39,6 +41,8 @@ async def test_basic(strategy_params, transport_type):
 
             # required by LocalRankStrategy
             os.environ["LOCAL_RANK"] = str(self.rank)
+            # required by HostStrategy
+            os.environ["HOSTNAME"] = socket.gethostname()
 
         @endpoint
         async def put(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@ import torchstore as ts
 from monarch.actor import Actor, current_rank, endpoint
 from torch.distributed._tensor import distribute_tensor
 from torch.distributed.device_mesh import init_device_mesh
+from torchstore.strategy import HostStrategy
 from torchstore.transport import TransportType
 
 logger = getLogger(__name__)
@@ -43,12 +44,15 @@ def main(file):
     pytest.main([file])
 
 
-def transport_plus_strategy_params():
+def transport_plus_strategy_params(with_host_strategy: bool = False):
     strategies = [
         (2, ts.LocalRankStrategy()),
         (1, None),  # ts.SingletonStrategy
         (1, ts.ControllerStorageVolumes()),
     ]
+
+    if with_host_strategy:
+        strategies.append((1, HostStrategy()))
 
     # Only run monarch/torchcomms tests if their respective env vars are set. Enabled by default.
     enabled_transport_types = [TransportType.MonarchRPC]

--- a/torchstore/strategy.py
+++ b/torchstore/strategy.py
@@ -11,6 +11,7 @@ multiple storage volumes. Strategies map client processes to storage volumes.
 """
 
 import os
+import socket
 from typing import TYPE_CHECKING
 
 from monarch.actor import current_rank
@@ -154,12 +155,14 @@ class HostStrategy(TorchStoreStrategy):
     """Assumes one storage volume per host.
 
     Each process uses 'HOSTNAME' to determine which storage volume to connect to.
+    This strategy requires the HOSTNAME environment variable to be set and assumes
+    one storage volume per local rank.
     """
 
     @classmethod
     def get_volume_id(cls):
         # Note: this should only called at spawn, which makes this safe.
-        return os.environ["HOSTNAME"]
+        return os.environ.get("HOSTNAME", socket.gethostname())
 
     @classmethod
     def get_client_id(cls):


### PR DESCRIPTION
Summary: Using socket.hostname as default volume_id for initialization. Similar approach is used in LocalRankStrategy

Differential Revision: D88797234
