### PR TITLE
If a DTensor is fully local treat it as a regular tensor

### DIFF
--- a/tests/test_tensor_slice.py
+++ b/tests/test_tensor_slice.py
@@ -350,7 +350,7 @@ async def test_fully_local_dtensor_put_get():
     """
     Test that fully local DTensors (Replicate placement) are stored as regular tensors.
 
-    This simulates the MoE use case where individual expert parameters are DTensors
+    This simulates the MoE use case in torchtitan where individual expert parameters are DTensors
     with Replicate() placement, but each rank puts different expert IDs.
     """
     from torch.distributed.tensor.placement_types import Replicate

--- a/torchstore/transport/pipe.py
+++ b/torchstore/transport/pipe.py
@@ -106,6 +106,9 @@ class Request:
         if isinstance(value, DTensor):
             # Check if DTensor is fully local (not actually distributed)
             # If so, treat it as a regular tensor to avoid collective requirements
+            # Note: this is due to behavior in torchtitan, where we have Replicate()
+            # placement which is not actually replicated along device-mesh
+            # todo: Revisit this if this is fixed in torchtitan
             if _is_dtensor_fully_local(value):
                 logger.debug(
                     f"DTensor with shape {value.shape} is fully local "


### PR DESCRIPTION
In some cases, like for the Qwen MoE model, we may have DTensors which are only pushed on one rank in the device mesh, instead of all ranks. This is the case for the expert layer parameters, like for example `model.layers.0.mlp.experts.2.gate_proj.weight `.

In these cases, we should treat it as a regular tensor in torchstore, instead of a DTensor to avoid getting an error like:
```
"DTensor 'policy_ver_0000000001.model.layers.0.mlp.experts.32.gate_proj.weight' is only partially committed. Not all shards have been stored yet. Please ensure all ranks complete their put() operations."
```

All work in this PR is from @allenwang28 

I tested this PR in torchforge, when I saw the error above, and confirmed that it fixes the issue. 
Test command in torchforge:
```
PYTHONPATH=. pytest -s tests/integration_tests/test_policy_update.py::TestWeightSync::test_sanity_check --config tests/integration_tests/fixtures/qwen3_30b_a3b.yaml
```