### PR TITLE
drop SSHJob from SPMD init; use host_mesh_from_store (#155)

### DIFF
--- a/torchstore/api.py
+++ b/torchstore/api.py
@@ -87,7 +87,7 @@ async def shutdown(store_name: str = DEFAULT_TORCHSTORE_NAME) -> None:
     Gracefully shuts down all storage volumes and controllers associated with the
     store. For SPMD-initialized stores, this delegates to the session cleanup
     path created by ``torchstore.spmd.initialize()``, which also tears down the
-    Monarch host mesh and the background SSHJob.
+    Monarch host mesh and the per-host worker subprocess each local rank 0 spawned.
 
     Args:
         store_name (str): Name of the store to shutdown. Defaults to DEFAULT_TORCHSTORE_NAME.

--- a/torchstore/spmd.py
+++ b/torchstore/spmd.py
@@ -8,32 +8,36 @@ import contextlib
 import logging
 import os
 import socket
-import sys
-from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
 import cloudpickle
 from monarch._src.actor import actor_mesh
-from monarch._src.job.job import SSHJob
-from monarch.actor import enable_transport, get_or_spawn_controller
+from monarch.actor import get_or_spawn_controller
 from torch.distributed import TCPStore
+
+try:
+    from monarch._src.spmd.host_mesh import host_mesh_from_store
+except ImportError as e:
+    _host_mesh_import_error: ImportError = e
+
+    def host_mesh_from_store(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(
+            "host_mesh_from_store() is not available. This environment was not built with a version of monarch "
+            "that includes this API. Try installing nightly monarch."
+        ) from _host_mesh_import_error
+
 
 import torchstore.api as _api
 from torchstore.controller import Controller
 from torchstore.strategy import HostStrategy, LocalRankStrategy, TorchStoreStrategy
-
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _spmd_key(store_name: str, suffix: str) -> str:
     return f"torchstore/spmd/{store_name}/{suffix}"
-
-
-def _host_key(group_rank: int) -> str:
-    return f"torchstore/spmd/hosts/{group_rank}"
 
 
 @dataclass(frozen=True)
@@ -90,33 +94,6 @@ class SPMDEnv:
         )
 
 
-def _create_ssh_job(
-    *,
-    python_exe: str,
-    ssh_args: Sequence[str],
-    monarch_port: int,
-    transport: str,
-) -> SSHJob:
-    try:
-        # only nightly monarch takes a transport arg for now
-        return SSHJob(
-            python_exe=python_exe,
-            ssh_args=ssh_args,
-            monarch_port=monarch_port,
-            transport=transport,
-        )
-    except TypeError as e:
-        if transport != "tcp":
-            raise RuntimeError(
-                "This Monarch runtime does not support custom SSHJob transports"
-            ) from e
-        return SSHJob(
-            python_exe=python_exe,
-            ssh_args=ssh_args,
-            monarch_port=monarch_port,
-        )
-
-
 # TODO: Move this to ExceptionGroup once we drop python 3.10
 @contextlib.contextmanager
 def _capture(errors: list[Exception]):
@@ -130,7 +107,7 @@ class _SPMDSession:
     """Resources created by ``torchstore.spmd.initialize()``.
 
     The ``rendezvous`` attribute is a ``torch.distributed.TCPStore`` that
-    callers can reuse for their own cross-rank coordination
+    callers can reuse for their own cross-rank coordination.
     """
 
     def __init__(
@@ -140,7 +117,6 @@ class _SPMDSession:
         controller: Controller,
         store_name: str,
         host_mesh: Any | None,
-        job: Any | None,
         is_primary: bool,
     ) -> None:
         self.rendezvous = rendezvous
@@ -148,7 +124,6 @@ class _SPMDSession:
         self.is_primary = is_primary
         self._store_name = store_name
         self._host_mesh = host_mesh
-        self._job = job
 
     async def shutdown(self) -> None:
         """Tear down TorchStore SPMD state and any Monarch resources created here.
@@ -167,22 +142,14 @@ class _SPMDSession:
                 _api.reset_client(self._store_name)
 
         # then clean up any other resources like the hostmesh
-        if self.is_primary:
+        if self.is_primary and self._host_mesh is not None:
             with _capture(errors):
-                await self._shutdown_primary_resources()
+                await self._host_mesh.shutdown()
+            self._host_mesh = None
 
         # TODO: Move this to ExceptionGroup once we drop python 3.10
         if errors:
             raise errors[0]
-
-    async def _shutdown_primary_resources(self) -> None:
-        if self._host_mesh is not None:
-            await self._host_mesh.shutdown()
-        elif self._job is not None:
-            self._job.kill()
-
-        self._host_mesh = None
-        self._job = None
 
 
 async def _shutdown_primary(
@@ -236,15 +203,16 @@ async def _shutdown_spmd_state(
         await _shutdown(session, store_name)
 
 
-async def _best_effort_cleanup(host_mesh: Any | None, job: Any | None) -> None:
+async def _best_effort_cleanup(host_mesh: Any | None) -> None:
     """Best-effort cleanup of partial init state. Logs instead of raising."""
-    try:
-        if host_mesh is not None:
+    if host_mesh is not None:
+        try:
             await host_mesh.shutdown()
-        elif job is not None:
-            job.kill()
-    except Exception:
-        logger.warning("Cleanup after SPMD init failure raised", exc_info=True)
+        except Exception:
+            logger.warning(
+                "torchstore.spmd: host mesh cleanup after init failure raised",
+                exc_info=True,
+            )
 
 
 def _storage_mesh(
@@ -281,23 +249,46 @@ async def initialize(
     *,
     env: SPMDEnv | None = None,
     rendezvous_timeout: timedelta = timedelta(seconds=120),
-    transport: str = "tcp",
-    python_exe: str | None = None,
+    transport: str = "ipc",
     monarch_port: int = 26600,
-    ssh_args: Sequence[str] = (),
 ) -> None:
     """Initialize TorchStore from a torchrun-style SPMD environment.
 
-    SPMD derives its storage topology from the strategy: one volume per host for
-    ``HostStrategy`` and one volume per rank for ``LocalRankStrategy``.
+    SPMD derives its storage topology from the strategy: one volume per host
+    for ``HostStrategy`` and one volume per rank for ``LocalRankStrategy``.
 
-    When ``env`` is omitted, it is populated from the
-    standard ``RANK`` / ``WORLD_SIZE`` / ``MASTER_ADDR`` / ``MASTER_PORT`` env
-    vars via :meth:`SPMDEnv.from_env`.
+    When ``env`` is omitted, topology is read from the standard ``RANK`` /
+    ``LOCAL_RANK`` / ``WORLD_SIZE`` / ``LOCAL_WORLD_SIZE`` / ``MASTER_ADDR``
+    / ``MASTER_PORT`` env vars via :meth:`SPMDEnv.from_env`. Callers that
+    need to drive init from an explicit config can build an ``SPMDEnv``
+    directly and pass it via ``env=``. All ranks then call
+    :func:`monarch._src.spmd.host_mesh.host_mesh_from_store` collectively —
+    global rank 0 gets a ``HostMesh`` back, and non-primary ranks get ``None``.
+    Global rank 0 then spawns TorchStore volumes on that mesh and broadcasts the
+    controller handle through the same ``TCPStore``.
 
-    This API bootstraps a fresh Monarch context for torchrun/torchx style callers. If
-    the process is already running inside Monarch, use ``torchstore.initialize``
-    with an explicit ``mesh`` instead.
+    ``transport`` selects the worker listen scheme. ``"ipc"`` (default)
+    uses a per-worker Unix socket and is limited to single-host
+    deployments; ``"tcp"``, ``"metatls"`` and ``"metatls-hostname"`` bind
+    on ``socket.getfqdn():monarch_port`` and work across hosts. IPC is
+    the default so that importing the helper doesn't silently open TCP
+    ports on user machines — multi-host callers must opt in explicitly.
+
+    This API bootstraps a fresh Monarch context for torchrun/torchx style
+    callers. If the process is already running inside Monarch, use
+    ``torchstore.initialize`` with an explicit ``mesh`` instead.
+
+    Args:
+        strategy: ``HostStrategy`` or ``LocalRankStrategy`` describing the
+            desired volume fan-out.
+        store_name: Unique name for this store instance.
+        env: Optional explicit SPMD environment; defaults to
+            :meth:`SPMDEnv.from_env`.
+        rendezvous_timeout: Timeout for the bootstrap ``TCPStore``.
+        transport: ``"ipc"`` (default), ``"tcp"``, ``"metatls"`` or
+            ``"metatls-hostname"``.
+        monarch_port: Port the worker binds on for TCP/metatls transports;
+            ignored for ``"ipc"``.
     """
 
     strategy = _validate_strategy(strategy)
@@ -323,36 +314,20 @@ async def initialize(
         is_master=(env.rank == 0),
         timeout=rendezvous_timeout,
     )
-    host_mesh: Any | None = None
-    job: Any | None = None
+    host_mesh = host_mesh_from_store(
+        rendezvous,
+        monarch_port=monarch_port,
+        name=f"torchstore_{store_name}",
+        transport=transport,
+        rank=env.rank,
+        local_rank=env.local_rank,
+        world_size=env.world_size,
+        local_world_size=env.local_world_size,
+    )
 
     try:
-        if env.local_rank == 0:
-            # only one process per host needs to set the hostname
-            rendezvous.set(_host_key(env.group_rank), socket.getfqdn().encode())
-
-        # gather all hostnames for the job
-        hostnames = [
-            rendezvous.get(_host_key(host_idx)).decode()
-            for host_idx in range(env.num_hosts)
-        ]
-        enable_transport(transport)
-
         controller_key = _spmd_key(store_name, "controller")
-
-        if env.rank == 0:
-            job = _create_ssh_job(
-                python_exe=sys.executable if python_exe is None else python_exe,
-                ssh_args=ssh_args,
-                monarch_port=monarch_port,
-                transport=transport,
-            )
-            job.add_mesh("hosts", hostnames)
-            job.apply()
-
-            host_mesh = job.state(cached_path=None).hosts
-            await host_mesh.initialized
-
+        if host_mesh is not None:
             storage_mesh = _storage_mesh(
                 strategy,
                 host_mesh,
@@ -379,13 +354,11 @@ async def initialize(
             controller=controller,
             store_name=store_name,
             host_mesh=host_mesh,
-            job=job,
             is_primary=(env.rank == 0),
         )
         _api._spmd_state_map[store_name] = session
     except Exception:
-        if env.rank == 0:
-            await _best_effort_cleanup(host_mesh, job)
+        await _best_effort_cleanup(host_mesh)
         raise
 
 


### PR DESCRIPTION
Summary:

SPMD initialization no longer depends on the Monarch job API. All ranks call `monarch._src.spmd.host_mesh.host_mesh_from_store(rendezvous, monarch_port=..., name=..., transport=..., rank=..., local_rank=..., world_size=..., local_world_size=...)` collectively; each local rank 0 spawns a `run_worker_loop_forever` subprocess via the upstream helper, global rank 0 gets back a `HostMesh` (non-primary ranks get `None`), and worker addresses travel through the caller-supplied bootstrap `TCPStore`. No `JobTrait` wrapper, no SSH.

`_SPMDSession` only owns the `HostMesh` now; worker subprocesses are managed entirely upstream and exit on their own via the parent-watch pipe when their local rank 0's process exits. Shutdown on the primary rank still awaits `host_mesh.shutdown()`. The `env=SPMDEnv(...)` override path is back — torchstore threads the SPMDEnv fields through host_mesh_from_store's new topology kwargs — so callers can drive init from an explicit config instead of torchelastic env vars. Default transport is `ipc` (matching the upstream helper) so importing doesn't silently open TCP ports on user machines; `tcp` / `metatls` / `metatls-hostname` are opt-in. `ssh_args`, `python_exe`, and `worker_env` stay gone.

Reviewed By: amirafzali

Differential Revision: D101934196


