### PR TITLE
add SPMD example and tests (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Key Features:
 - **Automatic transport selection** — POSIX shared memory for same-host, RDMA when available, with Gloo and Monarch RPC fallbacks
 - **Configurable storage strategies** — `LocalRankStrategy` (per-rank volumes), `HostStrategy` (per-host), extensible for your specific use case
 
-> **Note:** TorchStore requires distributed jobs to be launched with [Monarch](https://github.com/meta-pytorch/monarch). Direct SPMD support is planned.
+> **Note:** TorchStore supports both Monarch-native launches and SPMD entry points (`torchrun` / `torchx`). See [SPMD Usage](#spmd-usage-torchrun--torchx) below for the latter.
 
 
 > ⚠️ **Early Development Warning** TorchStore is currently in an experimental
@@ -137,6 +137,63 @@ if __name__ == "__main__":
 # [0] [1] Rank=[1] Fetched tensor([2]) from other_rank=2
 
 ```
+
+### SPMD Usage (torchrun / torchx)
+
+If your job is launched with `torchrun` or `torchx` rather than from inside a
+Monarch runtime, use `ts.initialize_spmd()` instead of `ts.initialize()`. It
+reads the standard `RANK` / `LOCAL_RANK` / `WORLD_SIZE` / `LOCAL_WORLD_SIZE` /
+`MASTER_ADDR` / `MASTER_PORT` env vars (via `ts.spmd.SPMDEnv.from_env()`) and
+bootstraps a fresh Monarch context for you. Global rank 0 collects the worker addresses and attaches to them to build the host mesh. Cross-rank coordination is
+the caller's responsibility, typically through `torch.distributed`.
+
+```python
+import asyncio
+import os
+
+import torch
+import torch.distributed as dist
+import torchstore as ts
+
+
+async def main() -> None:
+    rank = int(os.environ["RANK"])
+    dist.init_process_group("gloo")
+
+    await ts.initialize_spmd(strategy=ts.LocalRankStrategy())
+    try:
+        if rank == 0:
+            await ts.put("demo", torch.tensor([123], dtype=torch.int64))
+            print(f"[rank=0] wrote", flush=True)
+
+        dist.barrier()  # wait for rank 0's write before reading
+        value = await ts.get("demo")
+        print(f"[rank={rank}] got {value}", flush=True)
+    finally:
+        dist.barrier()  # wait for readers before tearing down storage
+        await ts.shutdown()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Launch with:
+
+```bash
+torchrun --standalone --nnodes=1 --nproc-per-node=2 your_script.py
+```
+
+The default `transport="ipc"` works for single-host launches. For
+multi-host jobs, pass `transport="tcp"` (or `"metatls"` /
+`"metatls-hostname"` at Meta) and `monarch_port=<port>` to control the
+port each local rank 0's worker binds on.
+
+To drive init from an explicit config instead of reading env vars,
+construct `ts.spmd.SPMDEnv(...)` directly and pass it via `env=`. For a
+complete runnable example, see
+[`example/torchstore_spmd.py`](example/torchstore_spmd.py).
 
 ### API Overview
 

--- a/example/torchstore_spmd.py
+++ b/example/torchstore_spmd.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# To run: torchrun --standalone --nnodes=1 --nproc-per-node=2 example/torchstore_spmd.py
+
+import asyncio
+import os
+
+import torch
+import torch.distributed as dist
+import torchstore as ts
+
+
+async def main() -> None:
+    rank = int(os.environ["RANK"])
+    dist.init_process_group("gloo")
+
+    await ts.initialize_spmd(strategy=ts.LocalRankStrategy())
+
+    try:
+        if rank == 0:
+            value = torch.tensor([123], dtype=torch.int64)
+            await ts.put("demo", value)
+            print(f"[rank=0] wrote {value}", flush=True)
+
+        dist.barrier()  # wait for rank 0's write before reading
+        value = await ts.get("demo")
+        print(f"[rank={rank}] got {value}", flush=True)
+    finally:
+        dist.barrier()  # wait for readers before tearing down storage
+        await ts.shutdown()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_spmd.py
+++ b/tests/test_spmd.py
@@ -1,0 +1,435 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+import logging
+import multiprocessing
+import os
+import queue
+import socket
+import traceback
+from datetime import timedelta
+from typing import Any
+
+import pytest
+import torch
+import torchstore as ts
+import torchstore.api as _api
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_WORLD_SIZE = 2
+_LOCAL_WORLD_SIZE = 2
+_PROCESS_TIMEOUT_SECS = 150.0
+_RENDEZVOUS_TIMEOUT = timedelta(seconds=20)
+_PORT_RETRY_TOKENS = ("EADDRINUSE", "address already in use")
+_STRATEGIES: dict[str, type[ts.TorchStoreStrategy]] = {
+    "host": ts.HostStrategy,
+    "local_rank": ts.LocalRankStrategy,
+}
+
+
+def _barrier(
+    rendezvous: Any,
+    *,
+    phase: str,
+    store_name: str,
+    rank: int,
+) -> None:
+    prefix = f"test/{store_name}/{phase}"
+    rendezvous.set(f"{prefix}/{rank}", b"1")
+    for peer in range(_WORLD_SIZE):
+        rendezvous.get(f"{prefix}/{peer}")
+
+
+async def _run_case(
+    *,
+    rank: int,
+    strategy_name: str,
+    store_name: str,
+) -> None:
+    await ts.initialize_spmd(
+        strategy=_STRATEGIES[strategy_name](),
+        store_name=store_name,
+        transport="ipc",
+        rendezvous_timeout=_RENDEZVOUS_TIMEOUT,
+    )
+    # Reuse the session's internal TCPStore for test-side barriers.
+    rendezvous = _api._spmd_state_map[store_name].rendezvous
+    try:
+        await ts.put(
+            f"rank_{rank}",
+            torch.tensor([rank], dtype=torch.int64),
+            store_name=store_name,
+        )
+
+        _barrier(rendezvous, phase="put_done", store_name=store_name, rank=rank)
+
+        for peer in range(_WORLD_SIZE):
+            value = await ts.get(
+                f"rank_{peer}",
+                store_name=store_name,
+            )
+            assert torch.equal(
+                value,
+                torch.tensor([peer], dtype=torch.int64),
+            )
+
+        _barrier(rendezvous, phase="get_done", store_name=store_name, rank=rank)
+    finally:
+        await ts.shutdown(store_name)
+
+
+def _reserve_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _child_main(
+    rank: int,
+    strategy_name: str,
+    store_name: str,
+    master_port: int,
+    results: Any,
+) -> None:
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(_WORLD_SIZE)
+    os.environ["LOCAL_WORLD_SIZE"] = str(_LOCAL_WORLD_SIZE)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    try:
+        asyncio.run(
+            _run_case(
+                rank=rank,
+                strategy_name=strategy_name,
+                store_name=store_name,
+            )
+        )
+        results.put({"rank": rank, "ok": True})
+    except Exception:
+        results.put(
+            {
+                "rank": rank,
+                "ok": False,
+                "error": traceback.format_exc(),
+            }
+        )
+
+
+def _run_spmd_case(strategy_name: str) -> None:
+    # _reserve_local_port() briefly closes its socket before handing the port
+    # to child processes, so a concurrent process on the test host can race us.
+    # The retry hides CI flakiness for this known TOCTOU; log each retry so
+    # chronic contention doesn't silently slow the suite.
+    last_errors: list[str] = []
+    max_attempts = 3
+    for attempt in range(1, max_attempts + 1):
+        store_name = f"torchstore_spmd_{strategy_name}"
+        master_port = _reserve_local_port()
+        errors = _run_spmd_case_once(
+            strategy_name=strategy_name,
+            store_name=store_name,
+            master_port=master_port,
+        )
+        if not errors:
+            return
+
+        last_errors = errors
+        port_conflict = any(
+            token in error for error in errors for token in _PORT_RETRY_TOKENS
+        )
+        if not port_conflict:
+            break
+        if attempt < max_attempts:
+            logger.warning(
+                "SPMD test %s hit a port conflict on attempt %d/%d; retrying",
+                strategy_name,
+                attempt,
+                max_attempts,
+            )
+
+    assert not last_errors, "\n\n".join(last_errors)
+
+
+def _run_spmd_case_once(
+    *,
+    strategy_name: str,
+    store_name: str,
+    master_port: int,
+) -> list[str]:
+    ctx = multiprocessing.get_context("spawn")
+    results = ctx.Queue()
+    processes: list[multiprocessing.Process] = []
+
+    for rank in range(_WORLD_SIZE):
+        process = ctx.Process(
+            target=_child_main,
+            args=(
+                rank,
+                strategy_name,
+                store_name,
+                master_port,
+                results,
+            ),
+        )
+        process.start()
+        processes.append(process)
+
+    for process in processes:
+        process.join(timeout=_PROCESS_TIMEOUT_SECS)
+
+    errors = []
+    timed_out_pids: set[int | None] = set()
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5.0)
+            timed_out_pids.add(process.pid)
+            errors.append(
+                f"rank process pid={process.pid} timed out in {strategy_name}"
+            )
+
+    outcomes = []
+    while len(outcomes) < _WORLD_SIZE:
+        try:
+            outcomes.append(results.get(timeout=1.0))
+        except queue.Empty:
+            break
+
+    for outcome in outcomes:
+        if not outcome["ok"]:
+            errors.append(
+                f"rank {outcome['rank']} failed in {strategy_name}:\n{outcome['error']}"
+            )
+
+    # Skip processes already reported above as timed out (their -15 exitcode
+    # would otherwise produce a duplicate error entry for the same PID).
+    for process in processes:
+        if process.pid in timed_out_pids:
+            continue
+        if process.exitcode not in (0, None):
+            errors.append(
+                f"rank process pid={process.pid} exited with code {process.exitcode}"
+            )
+
+    return errors
+
+
+class _UnsupportedStrategy(ts.TorchStoreStrategy):
+    @classmethod
+    def get_volume_id(cls) -> str:
+        return "0"
+
+    @classmethod
+    def get_client_id(cls) -> str:
+        return "0"
+
+
+class _FakeTeardown:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def call(self) -> None:
+        self.calls += 1
+
+
+class _FakeController:
+    def __init__(self) -> None:
+        self.teardown = _FakeTeardown()
+
+
+class _FakeRendezvous:
+    """In-memory stand-in for torch.distributed.TCPStore. A missing key on
+    .get() falls through to ``get_value`` (tests that need a synthetic primary
+    outcome pass it explicitly); ``get_error``, if set, wins and raises.
+    """
+
+    def __init__(
+        self,
+        *,
+        get_value: bytes | None = None,
+        get_error: Exception | None = None,
+    ) -> None:
+        self.values: dict[str, bytes] = {}
+        self._get_value = get_value
+        self._get_error = get_error
+
+    def set(self, key: str, value: str | bytes) -> None:
+        self.values[key] = value.encode() if isinstance(value, str) else value
+
+    def get(self, key: str) -> bytes:
+        if self._get_error is not None:
+            raise self._get_error
+        if key in self.values:
+            return self.values[key]
+        if self._get_value is None:
+            raise KeyError(key)
+        return self._get_value
+
+
+@pytest.fixture
+def primary_session():
+    """Factory fixture: builds a fake primary SPMDSession, registers it in
+    the state map, and auto-cleans up on teardown regardless of test outcome.
+    """
+    names: list[str] = []
+
+    def _build(
+        store_name: str,
+    ) -> tuple[_FakeController, _FakeRendezvous, "ts.spmd._SPMDSession"]:
+        controller = _FakeController()
+        rendezvous = _FakeRendezvous()
+        session = ts.spmd._SPMDSession(
+            rendezvous=rendezvous,
+            controller=controller,
+            store_name=store_name,
+            host_mesh=None,
+            is_primary=True,
+        )
+        _api._spmd_state_map[store_name] = session
+        names.append(store_name)
+        return controller, rendezvous, session
+
+    yield _build
+
+    for name in names:
+        _api._spmd_state_map.pop(name, None)
+        _api.reset_client(name)
+
+
+@pytest.fixture
+def non_primary_session():
+    """Factory fixture: builds a fake non-primary SPMDSession against a
+    caller-supplied rendezvous and auto-cleans up on teardown.
+    """
+    names: list[str] = []
+
+    def _build(
+        store_name: str,
+        rendezvous: _FakeRendezvous,
+    ) -> tuple[_FakeController, "ts.spmd._SPMDSession"]:
+        controller = _FakeController()
+        session = ts.spmd._SPMDSession(
+            rendezvous=rendezvous,
+            controller=controller,
+            store_name=store_name,
+            host_mesh=None,
+            is_primary=False,
+        )
+        _api._spmd_state_map[store_name] = session
+        names.append(store_name)
+        return controller, session
+
+    yield _build
+
+    for name in names:
+        _api._spmd_state_map.pop(name, None)
+        _api.reset_client(name)
+
+
+def test_local_rank_strategy_prefers_rank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.delenv("RANK", raising=False)
+    assert ts.LocalRankStrategy.get_client_id() == "1"
+
+    monkeypatch.setenv("RANK", "7")
+    assert ts.LocalRankStrategy.get_client_id() == "7"
+
+
+@pytest.mark.asyncio
+async def test_spmd_initialize_requires_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RANK", raising=False)
+    with pytest.raises(RuntimeError, match="RANK"):
+        await ts.spmd.initialize(strategy=ts.LocalRankStrategy())
+
+
+@pytest.mark.asyncio
+async def test_spmd_initialize_rejects_unsupported_strategy() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="HostStrategy or LocalRankStrategy",
+    ):
+        await ts.spmd.initialize(strategy=_UnsupportedStrategy())
+
+
+@pytest.mark.asyncio
+async def test_spmd_shutdown_delegates_to_session(primary_session) -> None:
+    store_name = "shutdown_delegates_to_session"
+    controller, rendezvous, _ = primary_session(store_name)
+
+    await ts.shutdown(store_name)
+
+    assert controller.teardown.calls == 1
+    assert rendezvous.values[ts.spmd._spmd_key(store_name, "shutdown")] == b"ok"
+    assert store_name not in _api._spmd_state_map
+
+
+@pytest.mark.asyncio
+async def test_spmd_session_shutdown_is_idempotent(primary_session) -> None:
+    store_name = "session_shutdown_is_idempotent"
+    controller, _, session = primary_session(store_name)
+
+    await session.shutdown()
+    await session.shutdown()
+
+    assert controller.teardown.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_spmd_shutdown_timeout_has_clear_error(non_primary_session) -> None:
+    store_name = "shutdown_timeout_has_clear_error"
+    rendezvous = _FakeRendezvous(get_error=RuntimeError("timed out"))
+    non_primary_session(store_name, rendezvous)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Timed out waiting for TorchStore shutdown",
+    ):
+        await ts.shutdown(store_name)
+
+    assert store_name not in _api._spmd_state_map
+
+
+@pytest.mark.asyncio
+async def test_spmd_shutdown_surfaces_primary_failure_to_non_primary(
+    non_primary_session,
+) -> None:
+    store_name = "shutdown_surfaces_primary_failure"
+    rendezvous = _FakeRendezvous(get_value=b"RuntimeError('teardown failed')")
+    non_primary_session(store_name, rendezvous)
+
+    with pytest.raises(
+        RuntimeError,
+        match="TorchStore SPMD shutdown failure",
+    ):
+        await ts.shutdown(store_name)
+
+    assert store_name not in _api._spmd_state_map
+
+
+@pytest.mark.asyncio
+async def test_spmd_initialize_validates_world_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "3")
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "2")
+    monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+    monkeypatch.setenv("MASTER_PORT", "29500")
+
+    with pytest.raises(ValueError, match="divisible"):
+        await ts.spmd.initialize(strategy=ts.LocalRankStrategy())
+
+
+@pytest.mark.parametrize("strategy_name", ["host", "local_rank"])
+def test_spmd_initialize_end_to_end(strategy_name: str) -> None:
+    _run_spmd_case(strategy_name)

--- a/torchstore/api.py
+++ b/torchstore/api.py
@@ -87,7 +87,7 @@ async def shutdown(store_name: str = DEFAULT_TORCHSTORE_NAME) -> None:
     Gracefully shuts down all storage volumes and controllers associated with the
     store. For SPMD-initialized stores, this delegates to the session cleanup
     path created by ``torchstore.spmd.initialize()``, which also tears down the
-    Monarch host mesh and the background SSHJob.
+    Monarch host mesh and the per-host worker subprocess each local rank 0 spawned.
 
     Args:
         store_name (str): Name of the store to shutdown. Defaults to DEFAULT_TORCHSTORE_NAME.

--- a/torchstore/spmd.py
+++ b/torchstore/spmd.py
@@ -8,32 +8,25 @@ import contextlib
 import logging
 import os
 import socket
-import sys
-from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
 import cloudpickle
 from monarch._src.actor import actor_mesh
-from monarch._src.job.job import SSHJob
-from monarch.actor import enable_transport, get_or_spawn_controller
+from monarch._src.spmd.host_mesh import host_mesh_from_store
+from monarch.actor import get_or_spawn_controller
 from torch.distributed import TCPStore
 
 import torchstore.api as _api
 from torchstore.controller import Controller
 from torchstore.strategy import HostStrategy, LocalRankStrategy, TorchStoreStrategy
 
-
 logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _spmd_key(store_name: str, suffix: str) -> str:
     return f"torchstore/spmd/{store_name}/{suffix}"
-
-
-def _host_key(group_rank: int) -> str:
-    return f"torchstore/spmd/hosts/{group_rank}"
 
 
 @dataclass(frozen=True)
@@ -90,33 +83,6 @@ class SPMDEnv:
         )
 
 
-def _create_ssh_job(
-    *,
-    python_exe: str,
-    ssh_args: Sequence[str],
-    monarch_port: int,
-    transport: str,
-) -> SSHJob:
-    try:
-        # only nightly monarch takes a transport arg for now
-        return SSHJob(
-            python_exe=python_exe,
-            ssh_args=ssh_args,
-            monarch_port=monarch_port,
-            transport=transport,
-        )
-    except TypeError as e:
-        if transport != "tcp":
-            raise RuntimeError(
-                "This Monarch runtime does not support custom SSHJob transports"
-            ) from e
-        return SSHJob(
-            python_exe=python_exe,
-            ssh_args=ssh_args,
-            monarch_port=monarch_port,
-        )
-
-
 # TODO: Move this to ExceptionGroup once we drop python 3.10
 @contextlib.contextmanager
 def _capture(errors: list[Exception]):
@@ -130,7 +96,7 @@ class _SPMDSession:
     """Resources created by ``torchstore.spmd.initialize()``.
 
     The ``rendezvous`` attribute is a ``torch.distributed.TCPStore`` that
-    callers can reuse for their own cross-rank coordination
+    callers can reuse for their own cross-rank coordination.
     """
 
     def __init__(
@@ -140,7 +106,6 @@ class _SPMDSession:
         controller: Controller,
         store_name: str,
         host_mesh: Any | None,
-        job: Any | None,
         is_primary: bool,
     ) -> None:
         self.rendezvous = rendezvous
@@ -148,7 +113,6 @@ class _SPMDSession:
         self.is_primary = is_primary
         self._store_name = store_name
         self._host_mesh = host_mesh
-        self._job = job
 
     async def shutdown(self) -> None:
         """Tear down TorchStore SPMD state and any Monarch resources created here.
@@ -167,22 +131,14 @@ class _SPMDSession:
                 _api.reset_client(self._store_name)
 
         # then clean up any other resources like the hostmesh
-        if self.is_primary:
+        if self.is_primary and self._host_mesh is not None:
             with _capture(errors):
-                await self._shutdown_primary_resources()
+                await self._host_mesh.shutdown()
+            self._host_mesh = None
 
         # TODO: Move this to ExceptionGroup once we drop python 3.10
         if errors:
             raise errors[0]
-
-    async def _shutdown_primary_resources(self) -> None:
-        if self._host_mesh is not None:
-            await self._host_mesh.shutdown()
-        elif self._job is not None:
-            self._job.kill()
-
-        self._host_mesh = None
-        self._job = None
 
 
 async def _shutdown_primary(
@@ -236,15 +192,16 @@ async def _shutdown_spmd_state(
         await _shutdown(session, store_name)
 
 
-async def _best_effort_cleanup(host_mesh: Any | None, job: Any | None) -> None:
+async def _best_effort_cleanup(host_mesh: Any | None) -> None:
     """Best-effort cleanup of partial init state. Logs instead of raising."""
-    try:
-        if host_mesh is not None:
+    if host_mesh is not None:
+        try:
             await host_mesh.shutdown()
-        elif job is not None:
-            job.kill()
-    except Exception:
-        logger.warning("Cleanup after SPMD init failure raised", exc_info=True)
+        except Exception:
+            logger.warning(
+                "torchstore.spmd: host mesh cleanup after init failure raised",
+                exc_info=True,
+            )
 
 
 def _storage_mesh(
@@ -281,23 +238,46 @@ async def initialize(
     *,
     env: SPMDEnv | None = None,
     rendezvous_timeout: timedelta = timedelta(seconds=120),
-    transport: str = "tcp",
-    python_exe: str | None = None,
+    transport: str = "ipc",
     monarch_port: int = 26600,
-    ssh_args: Sequence[str] = (),
 ) -> None:
     """Initialize TorchStore from a torchrun-style SPMD environment.
 
-    SPMD derives its storage topology from the strategy: one volume per host for
-    ``HostStrategy`` and one volume per rank for ``LocalRankStrategy``.
+    SPMD derives its storage topology from the strategy: one volume per host
+    for ``HostStrategy`` and one volume per rank for ``LocalRankStrategy``.
 
-    When ``env`` is omitted, it is populated from the
-    standard ``RANK`` / ``WORLD_SIZE`` / ``MASTER_ADDR`` / ``MASTER_PORT`` env
-    vars via :meth:`SPMDEnv.from_env`.
+    When ``env`` is omitted, topology is read from the standard ``RANK`` /
+    ``LOCAL_RANK`` / ``WORLD_SIZE`` / ``LOCAL_WORLD_SIZE`` / ``MASTER_ADDR``
+    / ``MASTER_PORT`` env vars via :meth:`SPMDEnv.from_env`. Callers that
+    need to drive init from an explicit config can build an ``SPMDEnv``
+    directly and pass it via ``env=``. All ranks then call
+    :func:`monarch._src.spmd.host_mesh.host_mesh_from_store` collectively —
+    global rank 0 gets a ``HostMesh`` back, and non-primary ranks get ``None``.
+    Global rank 0 then spawns TorchStore volumes on that mesh and broadcasts the
+    controller handle through the same ``TCPStore``.
 
-    This API bootstraps a fresh Monarch context for torchrun/torchx style callers. If
-    the process is already running inside Monarch, use ``torchstore.initialize``
-    with an explicit ``mesh`` instead.
+    ``transport`` selects the worker listen scheme. ``"ipc"`` (default)
+    uses a per-worker Unix socket and is limited to single-host
+    deployments; ``"tcp"``, ``"metatls"`` and ``"metatls-hostname"`` bind
+    on ``socket.getfqdn():monarch_port`` and work across hosts. IPC is
+    the default so that importing the helper doesn't silently open TCP
+    ports on user machines — multi-host callers must opt in explicitly.
+
+    This API bootstraps a fresh Monarch context for torchrun/torchx style
+    callers. If the process is already running inside Monarch, use
+    ``torchstore.initialize`` with an explicit ``mesh`` instead.
+
+    Args:
+        strategy: ``HostStrategy`` or ``LocalRankStrategy`` describing the
+            desired volume fan-out.
+        store_name: Unique name for this store instance.
+        env: Optional explicit SPMD environment; defaults to
+            :meth:`SPMDEnv.from_env`.
+        rendezvous_timeout: Timeout for the bootstrap ``TCPStore``.
+        transport: ``"ipc"`` (default), ``"tcp"``, ``"metatls"`` or
+            ``"metatls-hostname"``.
+        monarch_port: Port the worker binds on for TCP/metatls transports;
+            ignored for ``"ipc"``.
     """
 
     strategy = _validate_strategy(strategy)
@@ -323,36 +303,20 @@ async def initialize(
         is_master=(env.rank == 0),
         timeout=rendezvous_timeout,
     )
-    host_mesh: Any | None = None
-    job: Any | None = None
+    host_mesh = host_mesh_from_store(
+        rendezvous,
+        monarch_port=monarch_port,
+        name=f"torchstore_{store_name}",
+        transport=transport,
+        rank=env.rank,
+        local_rank=env.local_rank,
+        world_size=env.world_size,
+        local_world_size=env.local_world_size,
+    )
 
     try:
-        if env.local_rank == 0:
-            # only one process per host needs to set the hostname
-            rendezvous.set(_host_key(env.group_rank), socket.getfqdn().encode())
-
-        # gather all hostnames for the job
-        hostnames = [
-            rendezvous.get(_host_key(host_idx)).decode()
-            for host_idx in range(env.num_hosts)
-        ]
-        enable_transport(transport)
-
         controller_key = _spmd_key(store_name, "controller")
-
-        if env.rank == 0:
-            job = _create_ssh_job(
-                python_exe=sys.executable if python_exe is None else python_exe,
-                ssh_args=ssh_args,
-                monarch_port=monarch_port,
-                transport=transport,
-            )
-            job.add_mesh("hosts", hostnames)
-            job.apply()
-
-            host_mesh = job.state(cached_path=None).hosts
-            await host_mesh.initialized
-
+        if host_mesh is not None:
             storage_mesh = _storage_mesh(
                 strategy,
                 host_mesh,
@@ -379,13 +343,11 @@ async def initialize(
             controller=controller,
             store_name=store_name,
             host_mesh=host_mesh,
-            job=job,
             is_primary=(env.rank == 0),
         )
         _api._spmd_state_map[store_name] = session
     except Exception:
-        if env.rank == 0:
-            await _best_effort_cleanup(host_mesh, job)
+        await _best_effort_cleanup(host_mesh)
         raise
 
 


### PR DESCRIPTION
Summary:

Adds an end-to-end SPMD test suite and a runnable torchrun example that pair with the `host_mesh_from_store` refactor in the parent commit.

`tests/test_spmd.py` stands up both ranks in local subprocesses and drives the full bootstrap through `ts.initialize_spmd(transport="ipc", ...)` — no SSH stubbing, no hostname patching. It covers both `HostStrategy` and `LocalRankStrategy` end-to-end, plus unit coverage for shutdown, session idempotency, primary/non-primary error paths, and env-var validation. Session fixtures no longer fake a worker handle — worker lifecycle is entirely owned upstream by `host_mesh_from_store`, so the session only holds a host mesh (on primary ranks) and the tests assert against that directly.

`example/torchstore_spmd.py` is a minimal torchrun/gloo example; the README gains a matching "SPMD Usage (torchrun / torchx)" section covering env vars, the per-local-rank-0 subprocess bootstrap, and the `transport` / `monarch_port` knobs for multi-host launches.

Differential Revision: D101934195
