### PR TITLE
Self-heal InMemoryStore kv on shape mismatch

### DIFF
--- a/torchstore/storage_volume.py
+++ b/torchstore/storage_volume.py
@@ -154,6 +154,13 @@ class InMemoryStore(StorageImpl):
         Looks up the key in kv storage and extracts the tensor if it exists.
         Only asserts on type mismatches between existing data and incoming request.
 
+        Self-heals on shape mismatch: if a stale entry has a different shape
+        than the incoming PUT (e.g. a prior delete was lost / silently dropped),
+        evict the stale entry so a fresh allocation runs. Without this, the
+        downstream client `shm_tensor.copy_(new_tensor)` crashes with
+        "size of tensor a (X) must match tensor b (Y) at dim N" because the
+        handshake hands back a descriptor sized for the OLD tensor.
+
         Args:
             request: The incoming put request
 
@@ -173,6 +180,29 @@ class InMemoryStore(StorageImpl):
             assert (
                 request.tensor_slice is None
             ), "Existing data is a regular tensor but incoming request has tensor_slice (DTensor)"
+            # Self-heal on shape mismatch: drop stale entry, return None so
+            # caller allocates fresh. Uses request.tensor_meta (set by
+            # meta_only() when the original request had a tensor_val); if
+            # tensor_meta is missing, fall back to tensor_val. Skip check
+            # when neither is available (e.g. GET-only path).
+            incoming_shape: torch.Size | None = None
+            if request.tensor_meta is not None:
+                incoming_shape = request.tensor_meta[0]
+            elif isinstance(request.tensor_val, torch.Tensor):
+                incoming_shape = request.tensor_val.shape
+            if (
+                incoming_shape is not None
+                and current_object.shape != incoming_shape
+            ):
+                logger.warning(
+                    "InMemoryStore: evicting stale kv entry for key=%s "
+                    "(existing shape=%s, new shape=%s)",
+                    request.key,
+                    tuple(current_object.shape),
+                    tuple(incoming_shape),
+                )
+                del self.kv[request.key]
+                return None
             return current_object
 
         if isinstance(current_object, dict):

--- a/torchstore/transport/types.py
+++ b/torchstore/transport/types.py
@@ -104,6 +104,12 @@ class Request:
     tensor_slice: TensorSlice | None = None
     objects: Any | None = None
     is_object: bool = False
+    # Shape/dtype of the local tensor for this request, propagated through
+    # meta_only() so the storage volume can validate the incoming PUT against
+    # any existing kv entry without needing the full tensor data. Set
+    # automatically by meta_only() when tensor_val is present; callers should
+    # not set this directly.
+    tensor_meta: tuple[torch.Size, torch.dtype] | None = None
 
     @classmethod
     def from_any(
@@ -208,11 +214,21 @@ class Request:
         return cls(key=key, tensor_slice=copy.deepcopy(tensor_slice))
 
     def meta_only(self) -> "Request":
-        """Returns a copy of this request with tensor_val set to None."""
+        """Returns a copy of this request with tensor_val set to None.
+
+        Shape/dtype of the original tensor (if any) is preserved in
+        tensor_meta so server-side handlers can compare against existing
+        kv entries (e.g. detect stale-shape mismatches that would otherwise
+        crash the client during in-place SHM copy).
+        """
+        tensor_meta: tuple[torch.Size, torch.dtype] | None = self.tensor_meta
+        if tensor_meta is None and self.tensor_val is not None:
+            tensor_meta = (self.tensor_val.shape, self.tensor_val.dtype)
         return Request(
             key=self.key,
             tensor_val=None,
             tensor_slice=self.tensor_slice,
             objects=self.objects,
             is_object=self.is_object,
+            tensor_meta=tensor_meta,
         )


### PR DESCRIPTION
Summary:
InMemoryStore._extract_existing now self-heals when an incoming PUT's
tensor shape differs from the cached entry. Without this, a stale kv
entry left behind by a lost / silently-dropped client delete causes the
next PUT to the same key to crash inside `shm_tensor.copy_(new_tensor)`
with "size of tensor a (X) must match tensor b (Y)" — because the
handshake hands back a descriptor sized for the OLD tensor.

The shape check uses Request.tensor_meta, a new field automatically
populated by Request.meta_only() so the storage volume can validate
PUT shape without needing the full tensor data.

Differential Revision: D103627588


