### PR TITLE
Clear transport caches on TorchStore delete (#161)

### DIFF
--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -240,6 +240,57 @@ class TestSharedMemoryCache:
 
         assert len(cache._storages) == 0
 
+    def test_delete_clears_matching_keys(self):
+        """Test deleting keys removes only matching cache entries."""
+        cache = SharedMemoryCache()
+        tensor1 = allocate_shared_tensor(torch.Size([5, 5]), torch.float32)
+        tensor2 = allocate_shared_tensor(torch.Size([5, 5]), torch.float32)
+        descriptor1 = SharedMemoryDescriptor.from_tensor(tensor1)
+        descriptor2 = SharedMemoryDescriptor.from_tensor(tensor2)
+        assert descriptor1 is not None
+        assert descriptor2 is not None
+
+        try:
+            cache.attach("key1", descriptor1)
+            cache.attach("key2", descriptor2)
+
+            cache.delete({"key1", "missing"})
+
+            assert all(cache_key[0] != "key1" for cache_key in cache._storages)
+            assert any(cache_key[0] == "key2" for cache_key in cache._storages)
+
+            cache.delete({"key2"})
+
+            assert len(cache._storages) == 0
+        finally:
+            cache.clear()
+
+    def test_transport_context_delete_clears_shared_memory_cache(self):
+        """Test TransportContext.delete forwards key invalidation to SHM cache."""
+        ctx = TransportContext()
+        cache = ctx.get(SharedMemoryCache)
+        tensor1 = allocate_shared_tensor(torch.Size([5, 5]), torch.float32)
+        tensor2 = allocate_shared_tensor(torch.Size([5, 5]), torch.float32)
+        descriptor1 = SharedMemoryDescriptor.from_tensor(tensor1)
+        descriptor2 = SharedMemoryDescriptor.from_tensor(tensor2)
+        assert descriptor1 is not None
+        assert descriptor2 is not None
+
+        try:
+            cache.attach("key1", descriptor1)
+            cache.attach("key2", descriptor2)
+
+            ctx.delete("key1")
+
+            assert all(cache_key[0] != "key1" for cache_key in cache._storages)
+            assert any(cache_key[0] == "key2" for cache_key in cache._storages)
+
+            ctx.delete(["key2", "missing"])
+
+            assert len(cache._storages) == 0
+        finally:
+            ctx.clear()
+
     @pytest.mark.asyncio
     async def test_cache_reuse_on_same_key_puts(self, ref):
         """Test that putting twice to same key with same-spec tensor reuses cache entry."""

--- a/torchstore/client.py
+++ b/torchstore/client.py
@@ -414,6 +414,7 @@ class LocalClient:
             *[delete_from_volume(volume_id) for volume_id in volume_map]
         )
 
+        self.strategy.transport_context.delete(key)
         latency_tracker.track_e2e()
 
     async def exists(self, key: str) -> bool:

--- a/torchstore/storage_volume.py
+++ b/torchstore/storage_volume.py
@@ -87,6 +87,7 @@ class StorageVolume(Actor):
     @endpoint
     async def delete(self, key: str) -> None:
         await self.store.delete(key)
+        self.store.transport_context.delete(key)
 
     @endpoint
     async def reset(self) -> None:

--- a/torchstore/transport/buffers.py
+++ b/torchstore/transport/buffers.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import Any, TYPE_CHECKING, TypeVar
 
 import torch
@@ -18,6 +19,14 @@ if TYPE_CHECKING:
 
 class TransportCache(ABC):
     """Base class for per-transport caches stored in TransportContext."""
+
+    def delete(self, keys: set[str]) -> None:
+        """Delete per-key cache entries.
+
+        Most transport caches are not keyed by TorchStore key, so their default
+        behavior is a no-op.
+        """
+        return
 
     @abstractmethod
     def clear(self) -> None:
@@ -50,6 +59,14 @@ class TransportContext:
         for cache in self._caches.values():
             cache.clear()
         self._caches.clear()
+
+    def delete(self, keys: str | Iterable[str]) -> None:
+        """Delete cache entries associated with one or more TorchStore keys."""
+        key_set = {keys} if isinstance(keys, str) else set(keys)
+        if not key_set:
+            return
+        for cache in self._caches.values():
+            cache.delete(key_set)
 
 
 class TransportBuffer:

--- a/torchstore/transport/shared_memory.py
+++ b/torchstore/transport/shared_memory.py
@@ -212,8 +212,6 @@ class SharedMemoryCache(TransportCache):
 
     Caches at the storage level using (key, storage_handle) as cache key.
     Different views of the same storage share the same cached mmap and pin.
-    Stale entries (after delete/re-PUT) are never accessed because the server
-    returns new handles.
     """
 
     def __init__(self):
@@ -250,6 +248,13 @@ class SharedMemoryCache(TransportCache):
         for storage in self._storages.values():
             unpin_memory(storage)
         self._storages.clear()
+
+    def delete(self, keys: set[str]) -> None:
+        """Clear cached shared-memory mappings for deleted TorchStore keys."""
+        cache_keys = [cache_key for cache_key in self._storages if cache_key[0] in keys]
+        for cache_key in cache_keys:
+            storage = self._storages.pop(cache_key)
+            unpin_memory(storage)
 
     def __del__(self):
         self.clear()


### PR DESCRIPTION
Summary:

- Add a generic TransportContext.delete(key|keys) interface
- Implement SharedMemoryCache invalidation for deleted TorchStore keys
- Call transport context eviction from both client-side and storage-volume delete paths.

Differential Revision: D104603849


