### PR TITLE
Add xccl transport for device-resident put/get on Intel XPU

### DIFF
--- a/example/torchstore_rl.py
+++ b/example/torchstore_rl.py
@@ -13,15 +13,40 @@ import torch
 import torchstore as ts
 from monarch.actor import Actor, current_rank, endpoint, shutdown_context, this_host
 
-# Run the example : python example/torchstore_rl.py
+# Run the example:
+#   CUDA: python example/torchstore_rl.py
+#   XPU:  python example/torchstore_rl.py   (autodetected; oneCCL env from
+#         ~/env-3.sh and run_deepseek.sh's TCP block must already be set)
 
 
-def set_cuda_visible_devices(devices: str) -> None:
-    os.environ["CUDA_VISIBLE_DEVICES"] = devices
+def _accelerator() -> str:
+    """Return ``"cuda"`` or ``"xpu"`` based on what's available, else ``"cpu"``."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
+
+
+_ACCEL = _accelerator()
+
+
+def _set_visible_devices(devices: str) -> None:
+    """Pin one process to a single accelerator tile.
+
+    Sets the env var that the active backend honors —
+    ``CUDA_VISIBLE_DEVICES`` for CUDA, ``ZE_AFFINITY_MASK`` for XPU.
+    """
+    if _ACCEL == "cuda":
+        os.environ["CUDA_VISIBLE_DEVICES"] = devices
+    elif _ACCEL == "xpu":
+        os.environ["ZE_AFFINITY_MASK"] = devices
 
 
 class Learner(Actor):
     def __init__(self):
+        # Trainer stays on CPU for the toy model — keeps the example
+        # focused on weight-sharing semantics, not training perf.
         self.device = torch.device("cpu")
         self.model = torch.nn.Linear(4, 4, bias=False, device=self.device)
         self.optim = torch.optim.AdamW(
@@ -44,47 +69,45 @@ class Learner(Actor):
         torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
         self.optim.step()
         print("[learner] weights: ", self.model.state_dict())
-        # Put weights in to torch.store
         await ts.put_state_dict(self.model.state_dict(), key="toy_app")
 
 
 class Generator(Actor):
     def __init__(self):
-        self.model = torch.nn.Linear(4, 4, bias=False, device="cuda")
+        self.device = torch.device(_ACCEL if _ACCEL != "cpu" else "cpu")
+        self.model = torch.nn.Linear(4, 4, bias=False, device=self.device)
         self.index = current_rank()["gpus"]
 
     @endpoint
     async def update_weights(self):
         print(f"[generator {self.index}] original weights: {self.model.state_dict()}")
-        # Fetch weights from torch.store
         await ts.get_state_dict(key="toy_app", user_state_dict=self.model.state_dict())
         print(f"[generator {self.index}] new weights: {self.model.state_dict()}")
 
     @endpoint
     async def generate(self, inputs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        inputs = inputs.to("cuda")
+        inputs = inputs.to(self.device)
         logits = self.model(inputs)
         reward = torch.sum(logits)
         return logits, reward
 
 
 async def main():
-    """
-    The example code shows how to use torchstore to share weights between
-    trainer/learner and generator apps. The weights are shared synchronously
-    between the two apps.
+    """Trainer/generator weight-sharing demo. The chosen accelerator
+    (CUDA, XPU, or CPU fallback) is autodetected from what's available
+    on the host; transport selection inside TorchStore is automatic
+    (SHM intra-host, xccl on XPU, gloo otherwise).
     """
     num_learners = 1
     num_generators = 1
 
-    # TODO: Show weights re-sharding usecase.
     learner_mesh = this_host().spawn_procs(
         per_host={"gpus": num_learners},
-        bootstrap=partial(set_cuda_visible_devices, "0"),
+        bootstrap=partial(_set_visible_devices, "0"),
     )
     gen_mesh = this_host().spawn_procs(
         per_host={"gpus": num_generators},
-        bootstrap=partial(set_cuda_visible_devices, "1"),
+        bootstrap=partial(_set_visible_devices, "1"),
     )
 
     await ts.initialize()
@@ -92,13 +115,14 @@ async def main():
     learner = learner_mesh.spawn("learner", Learner)
     generators = gen_mesh.spawn("generator", Generator)
 
+    seed_device = _ACCEL if _ACCEL != "cpu" else "cpu"
     logits, reward = await generators.generate.call_one(
-        torch.randn(4, 4, device="cuda")
+        torch.randn(4, 4, device=seed_device)
     )
     for _ in range(3):
         await learner.step.call_one(logits, reward)
         logits, reward = await generators.generate.call_one(
-            torch.randn(4, 4, device="cuda")
+            torch.randn(4, 4, device=seed_device)
         )
         await generators.update_weights.call_one()
 

--- a/example/torchstore_state_dict.py
+++ b/example/torchstore_state_dict.py
@@ -1,0 +1,214 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Multi-tensor state_dict round-trip via TorchStore.
+
+Mirrors the pattern an RL pipeline uses for trainer/generator weight
+sync:
+
+- A ``Trainer``-style actor on its own proc_mesh calls
+  ``ts.put_state_dict``.
+- A ``Generator``-style actor on a different proc_mesh calls
+  ``ts.get_state_dict`` to pull the weights back into pre-allocated
+  buffers.
+- Many tensors per state_dict (LoRA adapter shape).
+
+This exercises the per-tensor handshake-cache reuse in transports
+that build a process group (gloo, xccl) — a single-tensor smoke
+wouldn't catch a regression there.
+
+Device autodetect: cuda > xpu > cpu. Run with::
+
+    python example/torchstore_state_dict.py
+
+On Intel XPU (xccl/oneCCL backed) most systems need libfabric on
+the TCP provider for oneCCL handshake to succeed::
+
+    unset FI_TCP_IFACE
+    unset CCL_KVS_MODE
+    export FI_PROVIDER=tcp
+    export CCL_ATL_TRANSPORT=ofi
+    export CCL_ATL_OFI_PROVIDER=tcp
+    export CCL_PROCESS_LAUNCHER=hydra
+    export CCL_ZE_DISABLE_PORT_CHECK=1
+    export ZE_FLAT_DEVICE_HIERARCHY=FLAT
+    python example/torchstore_state_dict.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections import OrderedDict
+from functools import partial
+
+import torch
+import torchstore as ts
+from monarch.actor import Actor, endpoint, shutdown_context, this_host
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+log = logging.getLogger("state_dict_example")
+
+
+def _accelerator() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
+
+
+_ACCEL = _accelerator()
+KEY = "policy_state_dict"
+
+
+def _set_visible_devices(devices: str) -> None:
+    """Pin one process to a single accelerator tile.
+
+    Sets the env var the active backend honors —
+    ``CUDA_VISIBLE_DEVICES`` for CUDA, ``ZE_AFFINITY_MASK`` for XPU.
+    """
+    if _ACCEL == "cuda":
+        os.environ["CUDA_VISIBLE_DEVICES"] = devices
+    elif _ACCEL == "xpu":
+        os.environ["ZE_AFFINITY_MASK"] = devices
+
+
+def _make_state_dict(seed: int) -> OrderedDict[str, torch.Tensor]:
+    """Build a small multi-tensor state_dict (LoRA-shaped).
+
+    Several distinct tensors so ``put_batch`` actually loops; a
+    single-tensor put would short-circuit handshake reuse.
+    """
+    g = torch.Generator(device=_ACCEL).manual_seed(seed)
+    sd: OrderedDict[str, torch.Tensor] = OrderedDict()
+    for i in range(4):
+        sd[f"layer.{i}.lora_A.weight"] = torch.randn(8, 16, generator=g, device=_ACCEL)
+        sd[f"layer.{i}.lora_B.weight"] = torch.randn(16, 8, generator=g, device=_ACCEL)
+    return sd
+
+
+class Trainer(Actor):
+    """Publishes a state_dict via ts.put_state_dict."""
+
+    @endpoint
+    async def publish(self, seed: int) -> dict:
+        sd = _make_state_dict(seed)
+        await ts.put_state_dict(sd, KEY)
+        return {
+            k: {
+                "shape": tuple(v.shape),
+                "device": str(v.device),
+                "checksum": float(v.float().sum().item()),
+            }
+            for k, v in sd.items()
+        }
+
+
+class Generator(Actor):
+    """Pulls the state_dict via ts.get_state_dict into pre-allocated buffers."""
+
+    @endpoint
+    async def fetch(self, ref_seed_for_shapes: int) -> dict:
+        # Pre-allocate destination buffers with the right shapes;
+        # mirrors how an RL Generator pulls into its own
+        # model.state_dict().
+        sd = _make_state_dict(ref_seed_for_shapes)
+        for v in sd.values():
+            v.zero_()
+
+        sd = await ts.get_state_dict(KEY, user_state_dict=sd, strict=True)
+        return {
+            k: {
+                "shape": tuple(v.shape),
+                "device": str(v.device),
+                "checksum": float(v.float().sum().item()),
+            }
+            for k, v in sd.items()
+        }
+
+
+async def main() -> int:
+    log.info("accelerator: %s", _ACCEL)
+    if _ACCEL == "cpu":
+        log.warning(
+            "no GPU detected; running on CPU still validates the actor "
+            "wiring and gloo path."
+        )
+
+    # Actors live on their own meshes → separate OS processes from
+    # the controller's storage volume. Required for xccl (oneCCL's
+    # internal KVS is per-process); harmless for gloo/SHM.
+    trainer_mesh = this_host().spawn_procs(
+        name="trainer",
+        per_host={"gpus": 1},
+        bootstrap=partial(_set_visible_devices, "0"),
+    )
+    gen_mesh = this_host().spawn_procs(
+        name="generator",
+        per_host={"gpus": 1},
+        bootstrap=partial(_set_visible_devices, "1"),
+    )
+
+    log.info("ts.initialize ...")
+    await ts.initialize()
+    log.info("initialize OK")
+
+    trainer = trainer_mesh.spawn("trainer", Trainer)
+    generator = gen_mesh.spawn("generator", Generator)
+
+    seed = 17
+    log.info("trainer.publish(seed=%d) — multi-tensor put_state_dict", seed)
+    src_info = next(iter(await trainer.publish.call(seed)))[1]
+    log.info("trainer wrote %d tensors", len(src_info))
+    for k, v in src_info.items():
+        log.info(
+            "  %s: shape=%s device=%s checksum=%.6f",
+            k,
+            v["shape"],
+            v["device"],
+            v["checksum"],
+        )
+
+    log.info("generator.fetch — multi-tensor get_state_dict")
+    got_info = next(iter(await generator.fetch.call(seed)))[1]
+    log.info("generator got %d tensors", len(got_info))
+
+    failures: list[str] = []
+    for k, src in src_info.items():
+        if k not in got_info:
+            failures.append(f"missing: {k}")
+            continue
+        got = got_info[k]
+        if got["shape"] != src["shape"]:
+            failures.append(
+                f"{k}: shape mismatch src={src['shape']} got={got['shape']}"
+            )
+        if abs(got["checksum"] - src["checksum"]) > 1e-3:
+            failures.append(
+                f"{k}: checksum mismatch src={src['checksum']:.6f} "
+                f"got={got['checksum']:.6f}"
+            )
+
+    if failures:
+        for f in failures:
+            log.error("  %s", f)
+        log.error("STATE-DICT FAIL")
+        await ts.shutdown()
+        return 1
+
+    log.info("STATE-DICT PASS — %d tensors round-tripped", len(src_info))
+    await ts.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    rc = asyncio.run(main())
+    shutdown_context().get(timeout=2.0)
+    sys.exit(rc)

--- a/torchstore/transport/__init__.py
+++ b/torchstore/transport/__init__.py
@@ -26,6 +26,7 @@ from torchstore.transport.torchcomms.cache import (
 )
 from torchstore.transport.torchcomms.uniflow_buffer import TorchCommsTransportBuffer
 from torchstore.transport.types import Request, TensorSlice
+from torchstore.transport.xccl import xccl_available, XcclTransportBuffer
 
 if TYPE_CHECKING:
     from torchstore.strategy import StorageVolumeRef
@@ -39,14 +40,20 @@ class TransportType(Enum):
     TorchComms = auto()
     TorchCommsRDMA = TorchComms  # Backward compatible alias
     Gloo = auto()
+    XCCL = auto()  # Intel oneCCL via torch.distributed; device-resident on XPU
     SharedMemory = auto()  # POSIX shared memory for same-host transfers
 
 
 def get_available_transport(storage_volume_ref: "StorageVolumeRef") -> TransportType:
     """Determine the best available transport type for the given storage volume.
 
-    Prefers SharedMemory for same-host transfers, then TorchComms (Uniflow RDMA/NVLink),
-    then MonarchRDMA, then Gloo, otherwise falls back to MonarchRPC.
+    Order: SharedMemory (same-host) > TorchComms (Uniflow RDMA/NVLink) >
+    MonarchRDMA (ibverbs) > XCCL (XPU device-resident) > Gloo (TCP/CPU) >
+    MonarchRPC (last resort).
+
+    XCCL beats Gloo on XPU because it keeps tensors on device. Gloo is kept
+    as the universal cross-platform fallback for non-XPU hosts and as a
+    safety net if xccl init fails.
     """
     # Prefer SharedMemory for same-host transfers
     if SHM_ENABLED and is_local_to_volume(storage_volume_ref):
@@ -57,6 +64,8 @@ def get_available_transport(storage_volume_ref: "StorageVolumeRef") -> Transport
         return TransportType.TorchComms
     elif monarch_rdma_transport_available():
         return TransportType.MonarchRDMA
+    elif xccl_available():
+        return TransportType.XCCL
     elif gloo_available():
         return TransportType.Gloo
 
@@ -82,6 +91,7 @@ def create_transport_buffer(storage_volume_ref: "StorageVolumeRef") -> Transport
         TransportType.MonarchRPC: MonarchRPCTransportBuffer,
         TransportType.MonarchRDMA: MonarchRDMATransportBuffer,
         TransportType.Gloo: GlooTransportBuffer,
+        TransportType.XCCL: XcclTransportBuffer,
         TransportType.SharedMemory: SharedMemoryTransportBuffer,
     }
 

--- a/torchstore/transport/shared_memory.py
+++ b/torchstore/transport/shared_memory.py
@@ -52,14 +52,26 @@ MUTABLE_SHM = os.environ.get("TORCHSTORE_MUTABLE_SHM", "0") == "1"
 SHM_ENABLED = os.environ.get("TORCHSTORE_SHARED_MEMORY_ENABLED", "1") == "1"
 
 
-def pin_memory(storage: torch.UntypedStorage) -> None:
-    """Pin storage's memory for faster CUDA transfers.
+def _is_xpu_available() -> bool:
+    return hasattr(torch, "xpu") and torch.xpu.is_available()
 
-    Uses cudaHostRegister with cudaHostRegisterPortable flag to make the
-    memory accessible from all CUDA contexts. Pins the entire SHM segment
-    so all views benefit from DMA.
+
+def pin_memory(storage: torch.UntypedStorage) -> None:
+    """Pin storage's memory for faster accelerator transfers.
+
+    On CUDA, uses cudaHostRegister with cudaHostRegisterPortable so the
+    memory is accessible from all CUDA contexts. The entire SHM segment
+    is pinned so all views benefit from DMA.
+
+    On XPU, ``torch.xpu`` does not yet expose a portable host-register
+    equivalent, so this becomes a no-op when XPU is the active backend.
+    Tensor copies still complete correctly; they just can't use
+    page-locked DMA.
     """
-    if not SHOULD_PIN_SHM or not torch.cuda.is_available():
+    if not SHOULD_PIN_SHM:
+        return
+    if not torch.cuda.is_available():
+        # XPU (or CPU) — no portable hostRegister API yet, skip pinning.
         return
 
     cudart = torch.cuda.cudart()
@@ -80,8 +92,10 @@ def pin_memory(storage: torch.UntypedStorage) -> None:
 
 
 def unpin_memory(storage: torch.UntypedStorage) -> None:
-    """Unpin storage's memory."""
-    if not SHOULD_PIN_SHM or not torch.cuda.is_available():
+    """Unpin storage's memory (no-op on XPU; CUDA-only otherwise)."""
+    if not SHOULD_PIN_SHM:
+        return
+    if not torch.cuda.is_available():
         return
 
     cudart = torch.cuda.cudart()
@@ -355,7 +369,7 @@ class SharedMemoryTransportBuffer(TransportBuffer):
             if not tensor.is_contiguous():
                 tensor = tensor.cpu().contiguous()
 
-            if tensor.is_cuda:
+            if tensor.is_cuda or tensor.device.type == "xpu":
                 devices_to_sync.add(tensor.device)
 
             if descriptor is not None:
@@ -376,7 +390,10 @@ class SharedMemoryTransportBuffer(TransportBuffer):
 
         # Wait for async copies (GPU->CPU DMA) on involved devices only
         for device in devices_to_sync:
-            torch.cuda.synchronize(device)
+            if device.type == "xpu":
+                torch.xpu.synchronize(device)
+            else:
+                torch.cuda.synchronize(device)
         latency_tracker.track_step("cuda_synchronize")
 
     async def handle_put_request(

--- a/torchstore/transport/torchcomms/cache.py
+++ b/torchstore/transport/torchcomms/cache.py
@@ -109,7 +109,10 @@ class RdmaTransportCache(TransportCache):
         """Map devices to legacy RdmaTransport indices; CPU uses index 0."""
         if isinstance(device, int):
             return device
-        return 0 if device.type == "cpu" else int(device.index)
+        if device.type == "cpu":
+            return 0
+        # CUDA, XPU, etc. — use the device index
+        return int(device.index)
 
     def put(self, key: str, device: torch.device | int) -> TransportAndAddress:
         assert _torchcomms_transport is not None
@@ -218,7 +221,7 @@ class UniflowCache(TransportCache):
 
     @staticmethod
     def device_to_id(device: torch.device | int) -> int:
-        """Map devices to Uniflow ids; CPU uses -1 and CUDA uses its index."""
+        """Map devices to Uniflow ids; CPU uses -1, CUDA/XPU use device index."""
         if isinstance(device, int):
             return device
         return -1 if device.type == "cpu" else int(device.index)

--- a/torchstore/transport/xccl.py
+++ b/torchstore/transport/xccl.py
@@ -1,0 +1,506 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""XCCL transport for TorchStore on Intel XPU.
+
+Mirrors gloo.py one-for-one but constructs a ``ProcessGroupXCCL`` instead
+of ``ProcessGroupGloo`` and keeps tensors device-resident on ``xpu``.
+
+Why a separate transport, not just a flag on the gloo path:
+
+- Gloo stages every transfer through CPU. For a Qwen3-0.6B+LoRA
+  ``state_dict`` (~600 MB), that's two device↔host copies plus TCP per
+  transfer.
+- xccl uses oneCCL's Level Zero queues directly, so the bytes never
+  leave XPU memory.
+
+This transport sits above gloo in the selection ladder; gloo remains
+the universal fallback for non-XPU hosts.
+"""
+
+import asyncio
+import os
+import socket
+import uuid
+from datetime import timedelta
+from logging import getLogger
+from typing import Any, TYPE_CHECKING
+
+import portpicker
+import torch
+import torch.distributed as dist
+from torch.distributed import PrefixStore, ProcessGroup, Store, TCPStore
+
+from torchstore.transport.buffers import TransportBuffer, TransportCache
+from torchstore.transport.types import Request
+
+if TYPE_CHECKING:
+    from torchstore.transport.buffers import TransportContext
+    from torchstore.transport.pipe import StorageVolumeRef
+
+
+logger = getLogger(__name__)
+
+
+# Same shape as gloo.py: per-volume cache of (master_addr, master_port, store_key)
+_store_addrs: dict[str, tuple[str, int, str]] = {}
+
+
+TORCHSTORE_XCCL_ENABLED = os.environ.get("TORCHSTORE_XCCL_ENABLED", "1") == "1"
+TORCHSTORE_XCCL_INIT_TIMEOUT = int(
+    os.environ.get("TORCHSTORE_XCCL_INIT_TIMEOUT", "120")
+)
+
+
+def xccl_available() -> bool:
+    """Return True iff the XCCL transport is usable on this host.
+
+    Conditions:
+    1. ``TORCHSTORE_XCCL_ENABLED`` is "1" (default).
+    2. ``torch.distributed.is_xccl_available()`` reports True.
+    3. ``torch.xpu.is_available()`` and at least one XPU device is visible.
+    """
+    if not TORCHSTORE_XCCL_ENABLED:
+        return False
+    if not hasattr(dist, "is_xccl_available"):
+        return False
+    try:
+        if not dist.is_xccl_available():
+            return False
+    except Exception:
+        return False
+    if not (hasattr(torch, "xpu") and torch.xpu.is_available()):
+        return False
+    try:
+        return torch.xpu.device_count() > 0
+    except Exception:
+        return False
+
+
+def _get_hostname() -> str:
+    return socket.getfqdn()
+
+
+def _xccl_factory(
+    store: Store,
+    rank: int,
+    world_size: int,
+    timeout: timedelta,
+    device: torch.device,
+    group_name: str,
+) -> ProcessGroup:
+    """Construct a 2-rank ProcessGroup with the XCCL backend bound to ``device``.
+
+    Mirrors ``_gloo_factory``: builds the C++ backend directly from the
+    supplied ``Store`` (no global state) and wraps it in a ``ProcessGroup``.
+    Avoids ``dist.init_process_group`` because it sets process-global state
+    and cannot be called more than once per process — each TorchStore
+    transfer needs its own private PG.
+
+    Avoids constructing ``ProcessGroupXCCL(store, rank, world_size)`` without
+    ``Options``: with no ``global_ranks_in_group``/``group_name`` set, oneCCL
+    spins up its own internal KVS server and the two ranks fail to meet
+    (``Unregister Barrier request!``).
+
+    ``group_name`` MUST be identical on both ranks. It namespaces oneCCL's
+    internal KVS rendezvous; when it differs (e.g. each rank picks a fresh
+    ``uuid4()``), each rank starts its own KVS and the first collective
+    fails with ``Unregister Barrier request!``. We pass the shared
+    ``store_key`` from the TCPStore handshake — both ranks see the same
+    value through ``XcclTransportBuffer.__getstate__`` / pickling.
+
+    ``device`` must name a specific XPU tile (``xpu:N``), not the bare
+    ``xpu`` type — oneCCL needs to know which tile to drive.
+    """
+    from torch.distributed import ProcessGroupXCCL
+
+    # Bind the device before init so oneCCL picks the right tile.
+    if device.type == "xpu":
+        torch.xpu.set_device(device)
+
+    # Match torch's own backend init: scope the store under the device name
+    # so multiple PGs can reuse a single underlying TCPStore without key
+    # collisions.
+    prefix = f"xccl/{device.type}:{device.index if device.index is not None else 0}/"
+    backend_prefix_store = PrefixStore(prefix, store)
+
+    options = ProcessGroupXCCL.Options()
+    options.global_ranks_in_group = list(range(world_size))
+    options.group_name = group_name
+    options._timeout = timeout
+
+    backend_class = ProcessGroupXCCL(backend_prefix_store, rank, world_size, options)
+
+    pg = ProcessGroup(backend_prefix_store, rank, world_size)
+    pg._set_default_backend(ProcessGroup.BackendType.XCCL)
+    pg._register_backend(device, ProcessGroup.BackendType.XCCL, backend_class)
+    pg._set_group_name(group_name)
+    return pg
+
+
+class XcclProcessGroupCache(TransportCache):
+    """Cache for XCCL process groups, keyed by store_key."""
+
+    def __init__(self) -> None:
+        self._process_groups: dict[str, ProcessGroup] = {}
+
+    def put(self, store_key: str, pg: ProcessGroup) -> None:
+        self._process_groups[store_key] = pg
+
+    def get(self, store_key: str) -> ProcessGroup:
+        return self._process_groups[store_key]
+
+    def clear(self) -> None:
+        self._process_groups.clear()
+
+
+class XcclTransportBuffer(TransportBuffer):
+    """Transport buffer using ``ProcessGroupXCCL`` for device-resident transfer.
+
+    Mirrors ``GlooTransportBuffer``: a fresh 2-rank PG per (client,
+    storage_volume) pair, coordinated via a ``TCPStore``. Differences
+    from gloo:
+
+    - Bound to ``xpu:0`` (or the local XPU rank if set), not ``cpu``.
+    - ``send``/``recv`` keep tensors on XPU; no ``.cpu()`` staging.
+    - Receive-side dest tensor is allocated on XPU.
+
+    Prerequisites:
+    - ``TORCHSTORE_XCCL_ENABLED=1`` (default).
+    - ``torch.xpu.is_available()`` and ``dist.is_xccl_available()``.
+    - oneCCL env block (``FI_PROVIDER=tcp``, ``CCL_ATL_TRANSPORT=ofi``,
+      etc.) — see ``run_spmd_xpu.sh`` for the canonical set.
+    """
+
+    supports_inplace_resharding = False
+
+    def __init__(self, storage_volume_ref: "StorageVolumeRef") -> None:
+        super().__init__(storage_volume_ref)
+
+        self.shape: torch.Size | None = None
+        self.dtype: torch.dtype | None = None
+
+        self.master_addr: str | None = None
+        self.master_port: int | None = None
+        self.store_key: str | None = None
+
+        self.is_object: bool = False
+        self.objects: Any = None
+
+        self._tcp_store: TCPStore | None = None
+        self._pg_task: asyncio.Task | None = None
+        self._send_task: asyncio.Task | None = None
+        self._recv_task: asyncio.Task | None = None
+
+    @staticmethod
+    def _xpu_device() -> torch.device:
+        """Pick the XPU tile this process should use.
+
+        Honors ``LOCAL_RANK`` if set, otherwise falls back to ``xpu:0``.
+        oneCCL needs a concrete tile, not bare ``xpu``.
+        """
+        if "LOCAL_RANK" in os.environ:
+            try:
+                return torch.device(f"xpu:{int(os.environ['LOCAL_RANK'])}")
+            except (TypeError, ValueError):
+                pass
+        return torch.device("xpu:0")
+
+    def requires_handshake(self, requests: list[Request]) -> bool:
+        """Skip handshake if we already have a cached PG for this volume."""
+        volume_id = self.storage_volume_ref.volume_id
+        if volume_id in _store_addrs:
+            cached_addr = _store_addrs[volume_id]
+            self.master_addr = cached_addr[0]
+            self.master_port = cached_addr[1]
+            self.store_key = cached_addr[2]
+            return False
+        return True
+
+    async def _pre_handshake(self) -> None:
+        """Create TCPStore, start client-side PG creation as a background task."""
+        volume_id = self.storage_volume_ref.volume_id
+
+        self.store_key = f"torchstore_xccl_{str(uuid.uuid4())[:8]}"
+        self.master_addr = _get_hostname()
+        self.master_port = portpicker.pick_unused_port()
+
+        logger.info(
+            f"[pid={os.getpid()}] Initiating xccl handshake with StorageVolume:[{volume_id}] "
+            f"using TCPStore at {self.master_addr}:{self.master_port}"
+        )
+
+        self._tcp_store = TCPStore(
+            host_name=self.master_addr,
+            port=self.master_port,
+            world_size=2,
+            is_master=True,
+            timeout=timedelta(seconds=TORCHSTORE_XCCL_INIT_TIMEOUT),
+            wait_for_workers=False,
+        )
+
+        tcp_store = self._tcp_store
+        device = self._xpu_device()
+        group_name = self.store_key
+
+        def create_pg():
+            return _xccl_factory(
+                store=tcp_store,
+                rank=0,
+                world_size=2,
+                timeout=timedelta(seconds=TORCHSTORE_XCCL_INIT_TIMEOUT),
+                device=device,
+                group_name=group_name,
+            )
+
+        self._pg_task = asyncio.create_task(asyncio.to_thread(create_pg))
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state["storage_volume_ref"] = None
+        state["_tcp_store"] = None
+        state["_pg_task"] = None
+        state["_send_task"] = None
+        state["_recv_task"] = None
+        return state
+
+    async def recv_handshake(
+        self,
+        ctx: "TransportContext",
+        entries: list[tuple[Request, Any]],
+    ) -> list[None]:
+        """Storage-side: build the PG as rank 1 and stash it in the context cache."""
+        logger.info(
+            f"[pid={os.getpid()}] Storage volume setting up xccl process group with TCPStore at "
+            f"{self.master_addr}:{self.master_port}"
+        )
+
+        master_addr = self.master_addr
+        master_port = self.master_port
+        device = self._xpu_device()
+        group_name = self.store_key
+
+        def create_pg():
+            tcp_store = TCPStore(
+                host_name=master_addr,
+                port=master_port,
+                world_size=2,
+                is_master=False,
+                timeout=timedelta(seconds=TORCHSTORE_XCCL_INIT_TIMEOUT),
+            )
+            return _xccl_factory(
+                store=tcp_store,
+                rank=1,
+                world_size=2,
+                timeout=timedelta(seconds=TORCHSTORE_XCCL_INIT_TIMEOUT),
+                device=device,
+                group_name=group_name,
+            )
+
+        pg = await asyncio.to_thread(create_pg)
+        ctx.get(XcclProcessGroupCache).put(self.store_key, pg)
+
+        logger.info(
+            f"Storage volume finished xccl process group setup for "
+            f"store_key={self.store_key}"
+        )
+        return [None]
+
+    async def _post_handshake(
+        self,
+        handshake_results: list[Any],
+        requests: list[Request],
+    ) -> None:
+        """Client-side: await the background PG creation, cache it."""
+        volume_id = self.storage_volume_ref.volume_id
+        pg = await self._pg_task
+
+        _store_addrs[volume_id] = (self.master_addr, self.master_port, self.store_key)
+        self.storage_volume_ref.transport_context.get(XcclProcessGroupCache).put(
+            self.store_key, pg
+        )
+
+        self._tcp_store = None
+        self._pg_task = None
+
+        logger.info(f"Finished xccl handshake with StorageVolume:[{volume_id}]")
+
+    async def _pre_put_hook(self, requests: list[Request]) -> None:
+        """Start sending tensor before put RPC."""
+        assert len(requests) == 1
+        request = requests[0]
+
+        if request.is_object:
+            self.is_object = True
+            return
+
+        if request.tensor_val is None:
+            return
+
+        tensor = request.tensor_val
+        self.shape = tensor.shape
+        self.dtype = tensor.dtype
+
+        self._send_task = asyncio.create_task(
+            self._send_tensor(
+                tensor,
+                self.storage_volume_ref.transport_context,
+            )
+        )
+
+    async def handle_put_request(
+        self,
+        ctx: "TransportContext",
+        entries: list[tuple[Request, Any]],
+    ) -> list[Any]:
+        """Storage-side put: receive into a fresh XPU tensor."""
+        assert len(entries) == 1
+        request, maybe_tensor = entries[0]
+
+        if request.is_object:
+            self.is_object = True
+            return [request.objects]
+
+        tensor = maybe_tensor
+        if tensor is None:
+            tensor = torch.empty(
+                self.shape, dtype=self.dtype, device=self._xpu_device()
+            )
+
+        tensor = await self._receive_tensor(tensor, ctx)
+        return [tensor]
+
+    async def _pre_get_hook(self, requests: list[Request]) -> None:
+        """Start receiving tensor before get RPC."""
+        assert len(requests) == 1
+        request = requests[0]
+
+        meta = (
+            await self.storage_volume_ref.volume.get_meta.call_one(
+                [request.meta_only()]
+            )
+        )[0]
+
+        if request.tensor_slice is not None:
+            self.shape = torch.Size(request.tensor_slice.local_shape)
+            self.dtype = meta[1]
+        else:
+            if isinstance(meta, str) or meta is None:
+                self.is_object = True
+                return
+            self.shape = meta[0]
+            self.dtype = meta[1]
+
+        tensor = torch.empty(self.shape, dtype=self.dtype, device=self._xpu_device())
+
+        self._recv_task = asyncio.create_task(
+            self._receive_tensor(
+                tensor,
+                self.storage_volume_ref.transport_context,
+            )
+        )
+
+    async def handle_get_request(
+        self,
+        ctx: "TransportContext",
+        entries: list[tuple[Request, Any]],
+    ) -> None:
+        """Storage-side get: send the stored tensor back to the client."""
+        assert len(entries) == 1
+        _, data = entries[0]
+        if not isinstance(data, torch.Tensor):
+            self.is_object = True
+            self.objects = data
+            return
+
+        await self._send_tensor(data, ctx)
+
+    async def _handle_storage_volume_response(
+        self, requests: list[Request], transport_buffer: "TransportBuffer"
+    ) -> list[Any]:
+        if transport_buffer.is_object:
+            return [transport_buffer.objects]
+
+        if self._recv_task is not None:
+            tensor = await self._recv_task
+            self._recv_task = None
+            if tensor is None:
+                raise RuntimeError(
+                    f"receive_tensor returned None (is_object={self.is_object}, "
+                    f"shape={self.shape}, dtype={self.dtype})"
+                )
+            return [tensor]
+
+        raise RuntimeError(f"No recv task available (is_object={self.is_object})")
+
+    async def _receive_tensor(
+        self, tensor: torch.Tensor, transport_context: "TransportContext"
+    ) -> torch.Tensor:
+        """Receive a tensor on the bound XPU tile, no CPU staging.
+
+        Caller may pass a tensor on a different device; we land on the
+        local XPU regardless to keep the pg.recv on the registered backend.
+        """
+        target = self._xpu_device()
+        if tensor.device != target:
+            tensor = torch.empty(tensor.shape, dtype=tensor.dtype, device=target)
+
+        pg = transport_context.get(XcclProcessGroupCache).get(self.store_key)
+        my_rank = pg.rank()
+        remote_rank = 1 - my_rank
+
+        logger.debug(
+            f"xccl recv: shape={tensor.shape} dtype={tensor.dtype} "
+            f"device={tensor.device} from rank={remote_rank} "
+            f"my_rank={my_rank} store_key={self.store_key}"
+        )
+
+        def do_recv():
+            work = pg.recv([tensor], srcRank=remote_rank, tag=0)
+            work.wait()
+            torch.xpu.synchronize(target)
+
+        await asyncio.to_thread(do_recv)
+        logger.debug(f"xccl recv: completed shape={tensor.shape}")
+        return tensor
+
+    async def _send_tensor(
+        self, tensor: torch.Tensor, transport_context: "TransportContext"
+    ) -> None:
+        """Send a tensor from XPU directly. No CPU staging."""
+        # If the source tensor lives on a foreign device (CPU, another XPU
+        # tile), move it onto the bound tile first; oneCCL needs the tensor
+        # on the device the PG is registered against.
+        target = self._xpu_device()
+        if tensor.device != target:
+            tensor = tensor.to(target)
+        if not tensor.is_contiguous():
+            tensor = tensor.contiguous()
+
+        pg = transport_context.get(XcclProcessGroupCache).get(self.store_key)
+        my_rank = pg.rank()
+        remote_rank = 1 - my_rank
+
+        logger.debug(
+            f"xccl send: shape={tensor.shape} dtype={tensor.dtype} "
+            f"device={tensor.device} to rank={remote_rank} "
+            f"my_rank={my_rank} store_key={self.store_key}"
+        )
+
+        def do_send():
+            work = pg.send([tensor], dstRank=remote_rank, tag=0)
+            work.wait()
+            torch.xpu.synchronize(target)
+
+        await asyncio.to_thread(do_send)
+        logger.debug(f"xccl send: completed shape={tensor.shape}")
+
+    async def drop(self) -> None:
+        if self._send_task is not None:
+            await self._send_task
+            self._send_task = None
+        self.is_object = False
+        self.objects = None


### PR DESCRIPTION
## Summary

- New `XcclTransportBuffer` keeps `ts.put` / `ts.get` tensors on
  `xpu` end-to-end. Selector picks it above Gloo on XPU hosts; CUDA
  behavior is unchanged (`xccl_available()` returns False).
- Generalizes `example/torchstore_rl.py` to autodetect cuda/xpu/cpu.
- Adds `example/torchstore_state_dict.py`: trainer + generator
  actors round-trip a multi-tensor LoRA-shaped state_dict — mirrors
  RL weight-sync.
- Small XPU gates in `shared_memory.py` and `torchcomms/cache.py`.

## Why

For RL weight sync (~600 MB state_dict per step), gloo stages
through CPU twice + TCP. xccl keeps bytes on XPU over oneCCL —
hundreds of ms → tens of ms per refresh.

## Test plan

- [x] `pre-commit run` clean.
- [x] All three examples (`torchstore_rl`, `torchstore_spmd`,
      `torchstore_state_dict`) rc=0 on a 12×PVC node, torch
      2.12.0+xpu, bit-exact checksums.
- [ ] CUDA-host smoke — reviewer with CUDA access requested.
