### PR TITLE
separate cuda copy stream for tensor push (#172)

### DIFF
--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -4,10 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Unit tests for shared memory transport."""
+"""Tests for shared memory transport (unit tests + one e2e ts.put check)."""
+
+import os
 
 import pytest
 import torch
+import torchstore as ts
+from monarch.actor import Actor, current_rank, endpoint
+from torchstore.logging import init_logging
+from torchstore.transport import TransportType
 from torchstore.transport.buffers import TransportContext
 from torchstore.transport.shared_memory import (
     allocate_shared_tensor,
@@ -18,7 +24,7 @@ from torchstore.transport.shared_memory import (
     ShmContext,
 )
 from torchstore.transport.types import Request
-from torchstore.utils import get_local_hostname
+from torchstore.utils import get_local_hostname, spawn_actors
 
 
 class MockStorageVolumeRef:
@@ -672,6 +678,32 @@ class TestSharedMemoryTransportBufferGPU:
 
         assert torch.allclose(shm_tensor, tensor.cpu())
 
+    @pytest.mark.asyncio
+    async def test_gpu_put_does_not_block_on_unrelated_stream(self, ref) -> None:
+        buffer = SharedMemoryTransportBuffer(ref)
+        tensor = torch.randn(50, 50, device="cuda")
+        entries = [Request(key="test_key", tensor_val=tensor)]
+        shm_tensor = allocate_shared_tensor(tensor.shape, tensor.dtype)
+        descriptor = SharedMemoryDescriptor.from_tensor(shm_tensor)
+
+        await buffer._post_handshake([descriptor], entries)
+
+        unrelated = torch.cuda.Stream()
+        with torch.cuda.stream(unrelated):
+            torch.cuda._sleep(2_000_000_000)  # long kernel on an unrelated stream
+        assert not unrelated.query(), "sanity: unrelated stream should be busy"
+
+        # Warm PUT: segment already cached+pinned, so only the copy runs.
+        await buffer._post_handshake([descriptor], entries)
+
+        assert not unrelated.query(), (
+            "warm GPU PUT blocked on unrelated stream work "
+            "(device-wide sync regression)"
+        )
+
+        unrelated.synchronize()
+        assert torch.allclose(shm_tensor, tensor.cpu())
+
 
 class TestSharedMemoryTransportBufferBatch:
     """Tests for SharedMemoryTransportBuffer batch operations."""
@@ -893,6 +925,55 @@ class TestViewAwareSharedMemory:
         assert len(results) == 1
         assert results[0] is dest_tensor
         assert torch.allclose(dest_tensor, torch.arange(20, 70, dtype=torch.float32))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.asyncio
+async def test_shm_put_does_not_block_on_unrelated_stream() -> None:
+    # E2E: a warm SHM ts.put of a GPU tensor must not stall on unrelated GPU work.
+
+    class StreamProbeActor(Actor):
+        def __init__(self):
+            init_logging()
+            os.environ["LOCAL_RANK"] = str(current_rank().rank)
+
+        @endpoint
+        async def run(self):
+            assert torch.cuda.is_available()
+            key = "weights"
+            tensor = torch.randn(50, 50, device="cuda")
+
+            # Prime: first PUT allocates + pins the SHM segment (device-syncs).
+            await ts.put(key, tensor)
+
+            unrelated = torch.cuda.Stream()
+            with torch.cuda.stream(unrelated):
+                torch.cuda._sleep(2_000_000_000)  # long unrelated kernel
+            assert not unrelated.query(), "sanity: unrelated stream should be busy"
+
+            # Warm PUT: segment already pinned/cached, so only the copy runs.
+            await ts.put(key, tensor)
+
+            still_busy = not unrelated.query()
+            unrelated.synchronize()
+            assert still_busy, (
+                "warm ts.put blocked on unrelated stream work "
+                "(device-wide sync regression)"
+            )
+
+            # Sanity: value round-trips through the store.
+            got = await ts.get(key)
+            assert torch.allclose(got.cpu(), tensor.cpu())
+
+    await ts.initialize(
+        num_storage_volumes=1,
+        strategy=ts.LocalRankStrategy(TransportType.SharedMemory),
+    )
+    actor_mesh = await spawn_actors(1, StreamProbeActor, "shm_stream_probe")
+    try:
+        await actor_mesh.run.call()
+    finally:
+        await ts.shutdown()
 
 
 if __name__ == "__main__":

--- a/torchstore/transport/buffers.py
+++ b/torchstore/transport/buffers.py
@@ -114,7 +114,7 @@ class TransportBuffer:
       2. Calls `_pre_get_hook(requests)` [CLIENT] - save metadata for response handling
       3. Sends to StorageVolume via `volume.get.call()`
       4. StorageVolume calls `handle_get_request(ctx, entries)` [STORAGE VOLUME]
-      5. Client calls `_handle_storage_volume_response(requests, response)` [CLIENT]
+      5. Client calls `_handle_storage_volume_response(requests, transport_buffer)` [CLIENT]
       6. Calls `drop()` [CLIENT] - cleanup resources
 
     Methods Called on CLIENT (Local Process)
@@ -316,7 +316,7 @@ class TransportBuffer:
         pass
 
     async def _handle_storage_volume_response(
-        self, requests: list[Request], response: Any
+        self, requests: list[Request], transport_buffer: "TransportBuffer"
     ) -> list[Any]:
         raise NotImplementedError()
 

--- a/torchstore/transport/shared_memory.py
+++ b/torchstore/transport/shared_memory.py
@@ -334,15 +334,16 @@ class SharedMemoryTransportBuffer(TransportBuffer):
 
         For tensor requests: attaches to an existing SHM segment (if the SV
         returned a descriptor) or allocates a new one, then copies data with
-        non_blocking=True. For object requests: captures the object directly.
-        Synchronizes after all copies to ensure GPU->CPU DMA completes.
+        non_blocking=True. CUDA tensor copies run on request-local copy
+        streams. For object requests: captures the object directly. Waits on
+        the copy streams after all copies to ensure GPU->CPU DMA completes.
         """
         latency_tracker = LatencyTracker("post_handshake")
 
         shm_cache = self.storage_volume_ref.transport_context.get(SharedMemoryCache)
 
         self._contexts = []
-        devices_to_sync: set[torch.device] = set()
+        copy_streams: dict[torch.device, torch.cuda.Stream] = {}
         for request, descriptor in zip(requests, handshake_results, strict=True):
             key = request.key
             if request.is_object:
@@ -354,9 +355,6 @@ class SharedMemoryTransportBuffer(TransportBuffer):
 
             if not tensor.is_contiguous():
                 tensor = tensor.cpu().contiguous()
-
-            if tensor.is_cuda:
-                devices_to_sync.add(tensor.device)
 
             if descriptor is not None:
                 # Reuse existing segment
@@ -371,13 +369,21 @@ class SharedMemoryTransportBuffer(TransportBuffer):
 
             # Copy tensor data to shared memory
             shm_tensor = client_entry.get_tensor()
-            shm_tensor.copy_(tensor, non_blocking=True)
+            if tensor.is_cuda:
+                copy_stream = copy_streams.get(tensor.device)
+                if copy_stream is None:
+                    copy_stream = torch.cuda.Stream(device=tensor.device)
+                    copy_stream.wait_stream(torch.cuda.current_stream(tensor.device))
+                    copy_streams[tensor.device] = copy_stream
+                with torch.cuda.stream(copy_stream):
+                    shm_tensor.copy_(tensor, non_blocking=True)
+            else:
+                shm_tensor.copy_(tensor, non_blocking=True)
         latency_tracker.track_step("alloc_and_copy")
 
-        # Wait for async copies (GPU->CPU DMA) on involved devices only
-        for device in devices_to_sync:
-            torch.cuda.synchronize(device)
-        latency_tracker.track_step("cuda_synchronize")
+        for copy_stream in copy_streams.values():
+            copy_stream.synchronize()
+        latency_tracker.track_step("cuda_copy_stream_synchronize")
 
     async def handle_put_request(
         self,


### PR DESCRIPTION
Summary:

Store was synchronizing the entire device stream after scheduling cuda copies. We should use a separate cuda stream so that the trainer is not blocked while pushing the previous policy.

Differential Revision: D109722729


