### PR TITLE
Use SHM PUT + MonarchRDMA GET for async RL weight sync

### DIFF
--- a/torchstore/api.py
+++ b/torchstore/api.py
@@ -387,10 +387,10 @@ async def put_state_dict(
             caller's GPU memory instead of copying data to a StorageVolume.
             First call registers handles; subsequent calls refresh staging
             buffers for non-contiguous params.
-        transfer_dtype (torch.dtype, optional): If set, cast weights to this
-            dtype for transfer. Only used with ``direct_rdma=True``. Allows
-            the source to keep higher-precision master weights (e.g. float32)
-            while transferring in a lower precision (e.g. bfloat16).
+        transfer_dtype (torch.dtype, optional): If set, cast floating-point
+            weights to this dtype for transfer. Allows the source to keep
+            higher-precision master weights (e.g. float32) while transferring
+            in a lower precision (e.g. bfloat16).
 
     Example:
         >>> model = torch.nn.Linear(10, 5)

--- a/torchstore/logging.py
+++ b/torchstore/logging.py
@@ -29,26 +29,38 @@ def init_logging():
 
 
 class LatencyTracker:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, level: int = logging.DEBUG) -> None:
         self.name = name
+        # Log level for this tracker's lines. Defaults to DEBUG; callers that
+        # want the timing visible by default (e.g. weight sync) pass INFO.
+        self.level = level
         self.last_step = self.start_time = time.perf_counter()
 
-    def _format_throughput(self, elapsed: float, tensor) -> str:
-        """Format throughput string if tensor is provided."""
-        if tensor is None or elapsed <= 0:
+    def _format_throughput(self, elapsed: float, tensor=None, nbytes=None) -> str:
+        """Format throughput string if a tensor or an explicit byte count is given.
+
+        ``nbytes`` lets callers report aggregate throughput for a whole batch
+        (e.g. a full state dict) without materializing a single tensor.
+        """
+        if elapsed <= 0:
             return ""
-        nbytes = tensor.numel() * tensor.element_size()
+        if nbytes is None:
+            if tensor is None:
+                return ""
+            nbytes = tensor.numel() * tensor.element_size()
         throughput_gbps = (nbytes / 1e9) / elapsed
         return f" ({throughput_gbps:.2f} GB/s)"
 
-    def track_step(self, step_name: str, tensor=None) -> None:
+    def track_step(self, step_name: str, tensor=None, nbytes=None) -> None:
         now = time.perf_counter()
         elapsed = now - self.last_step
-        throughput = self._format_throughput(elapsed, tensor)
-        logging.debug(f"{self.name}:{step_name} took {elapsed:.4f}s{throughput}")
+        throughput = self._format_throughput(elapsed, tensor, nbytes)
+        logging.log(
+            self.level, f"{self.name}:{step_name} took {elapsed:.4f}s{throughput}"
+        )
         self.last_step = now
 
-    def track_e2e(self) -> None:
-        logging.debug(
-            f"{self.name} took {time.perf_counter() - self.start_time} seconds"
-        )
+    def track_e2e(self, nbytes=None) -> None:
+        elapsed = time.perf_counter() - self.start_time
+        throughput = self._format_throughput(elapsed, nbytes=nbytes)
+        logging.log(self.level, f"{self.name} took {elapsed:.4f}s{throughput}")

--- a/torchstore/state_dict_utils.py
+++ b/torchstore/state_dict_utils.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from logging import getLogger
 from typing import Any
 
 import torch
@@ -15,11 +15,12 @@ from torch.distributed.checkpoint._nested_dict import (
     flatten_state_dict,
     unflatten_state_dict,
 )
+from torchstore.logging import LatencyTracker
 
 DELIM = "/"
 MAPPING = "MAPPING"
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -66,17 +67,35 @@ async def put_state_dict(
             keep higher-precision master weights while transferring in a
             lower precision (e.g. bfloat16).
     """
+    # Coarse weight-sync phase timing, logged at INFO (no TORCHSTORE_LOG_LEVEL
+    # =DEBUG / init_logging() needed) so callers can attribute latency to the
+    # major phases and compare the direct-RDMA vs CPU-staged transports.
+    tracker = LatencyTracker(
+        f"put_state_dict[{key}]/{'rdma' if direct_rdma else 'cpu_staged'}",
+        level=logging.INFO,
+    )
+
     if direct_rdma:
         await _put_state_dict_direct_rdma(store, state_dict, key, transfer_dtype)
+        # No throughput here: the direct-RDMA put only registers handles (and on
+        # repeat calls refreshes staging buffers). The bytes move on the
+        # generator's get via one-sided RDMA read, so there is no bulk transfer
+        # in put to report a GB/s for.
+        tracker.track_e2e()
         return
 
     flattened_state_dict, mapping = flatten_state_dict(state_dict)
+    tracker.track_step("flatten")
+    nbytes = _flattened_nbytes(flattened_state_dict)
 
     # Batch all tensor entries, then put the mapping separately.
     # The mapping is stored last so it acts as a commit marker for the state dict.
     entries = {f"{key}{DELIM}{k}": v for k, v in flattened_state_dict.items()}
     await store.put_batch(entries)
+    tracker.track_step("put_batch", nbytes=nbytes)
     await store.put(f"{key}{DELIM}{MAPPING}", mapping)
+    tracker.track_step("put_mapping")
+    tracker.track_e2e(nbytes=nbytes)
 
 
 async def get_state_dict(
@@ -93,11 +112,19 @@ async def get_state_dict(
     ``user_state_dict`` must be provided in this mode so the destination
     tensors are available for in-place writes.
     """
+    tracker = LatencyTracker(
+        f"get_state_dict[{key}]/{'rdma' if direct_rdma else 'cpu_staged'}",
+        level=logging.INFO,
+    )
+
     if direct_rdma:
         assert (
             user_state_dict is not None
         ), "user_state_dict is required for direct_rdma mode"
         await _get_state_dict_direct_rdma(store, key, user_state_dict)
+        # The direct-RDMA get is the actual GPU-to-GPU transfer, so report its
+        # throughput (comparable to the CPU-staged get_batch GB/s).
+        tracker.track_e2e(nbytes=_state_dict_nbytes(user_state_dict))
         return user_state_dict
 
     try:
@@ -107,6 +134,7 @@ async def get_state_dict(
         raise RuntimeError(
             f"Mapping is missing from the store. This most likely means there is no matching 'push' call for this key: {key=}"
         ) from e
+    tracker.track_step("get_mapping")
 
     user_flattened_state_dict, user_mapping = (
         flatten_state_dict(user_state_dict)
@@ -129,21 +157,34 @@ async def get_state_dict(
         get_batch_dict[get_id(fk)] = t
 
     results = await store.get_batch(get_batch_dict)
+    nbytes = _flattened_nbytes(results)
+    tracker.track_step("get_batch", nbytes=nbytes)
     fetched_state_dict = {fk: results[get_id(fk)] for fk in flattened_keys}
 
-    return unflatten_state_dict(fetched_state_dict, fetched_mapping)
+    out = unflatten_state_dict(fetched_state_dict, fetched_mapping)
+    tracker.track_step("unflatten")
+    tracker.track_e2e(nbytes=nbytes)
+    return out
+
+
+def _flattened_nbytes(flattened_state_dict) -> int:
+    """Total byte size of the tensor values in an already-flattened state dict."""
+    return sum(
+        t.numel() * t.element_size()
+        for t in flattened_state_dict.values()
+        if isinstance(t, torch.Tensor)
+    )
+
+
+def _state_dict_nbytes(state_dict) -> int:
+    """Total tensor byte size of a (possibly nested) state dict."""
+    sd, _ = flatten_state_dict(state_dict)
+    return _flattened_nbytes(sd)
 
 
 def _state_dict_size(state_dict):
     """Returns the size of the state dict in MBs"""
-    size = 0
-    sd, _ = flatten_state_dict(state_dict)
-    for tensor in sd.values():
-        if not isinstance(tensor, torch.Tensor):
-            continue
-
-        size += tensor.numel() * tensor.element_size()
-    return size // (1024 * 1024)
+    return _state_dict_nbytes(state_dict) // (1024 * 1024)
 
 
 # ---------------------------------------------------------------------------

--- a/torchstore/state_dict_utils.py
+++ b/torchstore/state_dict_utils.py
@@ -62,10 +62,9 @@ async def put_state_dict(
 
 
     Args:
-        transfer_dtype: If set, cast weights to this dtype for transfer.
-            Only used with ``direct_rdma=True``. Allows the source to
-            keep higher-precision master weights while transferring in a
-            lower precision (e.g. bfloat16).
+        transfer_dtype: If set, cast floating-point weights to this dtype for
+            transfer. Allows the source to keep higher-precision master weights
+            while transferring in a lower precision (e.g. bfloat16).
     """
     # Coarse weight-sync phase timing, logged at INFO (no TORCHSTORE_LOG_LEVEL
     # =DEBUG / init_logging() needed) so callers can attribute latency to the
@@ -86,6 +85,10 @@ async def put_state_dict(
 
     flattened_state_dict, mapping = flatten_state_dict(state_dict)
     tracker.track_step("flatten")
+    flattened_state_dict = _cast_floating_tensors(
+        flattened_state_dict, transfer_dtype
+    )
+    tracker.track_step("cast")
     nbytes = _flattened_nbytes(flattened_state_dict)
 
     # Batch all tensor entries, then put the mapping separately.
@@ -174,6 +177,21 @@ def _flattened_nbytes(flattened_state_dict) -> int:
         for t in flattened_state_dict.values()
         if isinstance(t, torch.Tensor)
     )
+
+
+def _cast_floating_tensors(flattened_state_dict, dtype):
+    if dtype is None:
+        return flattened_state_dict
+    return {
+        key: value.to(dtype)
+        if (
+            isinstance(value, torch.Tensor)
+            and value.is_floating_point()
+            and value.dtype != dtype
+        )
+        else value
+        for key, value in flattened_state_dict.items()
+    }
 
 
 def _state_dict_nbytes(state_dict) -> int:

--- a/torchstore/transport/__init__.py
+++ b/torchstore/transport/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from enum import auto, Enum
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,9 @@ from torchstore.transport.types import Request, TensorSlice
 
 if TYPE_CHECKING:
     from torchstore.strategy import StorageVolumeRef
+
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class TransportType(Enum):
@@ -63,11 +67,27 @@ def get_available_transport(storage_volume_ref: "StorageVolumeRef") -> Transport
     return TransportType.MonarchRPC
 
 
+def _log_transport_resolution(
+    storage_volume_ref: "StorageVolumeRef", transport_type: TransportType
+) -> None:
+    logger.info(
+        "[ts-transport] resolved=%s (uniflow=%s, tc_rdma=%s, monarch_rdma=%s, gloo=%s, shm=%s)",
+        transport_type.name,
+        torchcomms_uniflow_available(),
+        torchcomms_rdma_available(),
+        monarch_rdma_transport_available(),
+        gloo_available(),
+        SHM_ENABLED and is_local_to_volume(storage_volume_ref),
+    )
+
+
 def create_transport_buffer(storage_volume_ref: "StorageVolumeRef") -> TransportBuffer:
     transport_type = storage_volume_ref.default_transport_type
 
     if transport_type == TransportType.Unset:
         transport_type = get_available_transport(storage_volume_ref)
+
+    _log_transport_resolution(storage_volume_ref, transport_type)
 
     if transport_type == TransportType.TorchComms:
         # Keep one public transport type while the backend migrates from the


### PR DESCRIPTION
Summary:
- Use `direct_rdma=False` for async RL so generators read a stable StorageVolume snapshot instead of live trainer GPU tensors.
- Apply `transfer_dtype` on the CPU-staged `put_state_dict` path so fp32 master weights can transfer as bf16.
- Keep same-host trainer PUT on `SharedMemory` and set internal MAST `USE_TORCHCOMMS=0` so remote generator GET falls to `MonarchRDMA` for this landing path.
- Add 32B MAST validation config plus INFO timing/transport logs for weight-sync verification.

Differential Revision: D109719586


